### PR TITLE
[#11] 라이어게임 - 닉네임 설정 화면 구현

### DIFF
--- a/frontend/public/image/gun.svg
+++ b/frontend/public/image/gun.svg
@@ -1,0 +1,13 @@
+<svg width="1232" height="1188" viewBox="0 0 1232 1188" fill="none" xmlns="http://www.w3.org/2000/svg">
+<ellipse cx="616" cy="594" rx="616" ry="594" fill="#9A1818"/>
+<circle cx="616" cy="593" r="432" fill="#9A1818" fill-opacity="0.5"/>
+<circle cx="616" cy="593" r="402" stroke="#6B0404" stroke-opacity="0.3" stroke-width="60"/>
+<line y1="592.5" x2="116" y2="592.5" stroke="#6B0404" stroke-width="15"/>
+<line y1="-1.5" x2="1058" y2="-1.5" transform="matrix(1 -0.000869097 0.00102792 0.999999 87 593.92)" stroke="#6B0404" stroke-width="3"/>
+<line x1="1116" y1="591.5" x2="1232" y2="591.5" stroke="#6B0404" stroke-width="15"/>
+<path d="M722.325 281.852H511V117H722.325V281.852Z" fill="#9A1818"/>
+<path d="M721.663 1052.26H510.337V887.41H721.663V1052.26Z" fill="#9A1818"/>
+<line x1="614.5" y1="1188" x2="614.5" y2="6.31742e-08" stroke="#6B0404" stroke-width="3"/>
+<line x1="614.5" y1="1188" x2="614.5" y2="1072" stroke="#6B0404" stroke-width="15"/>
+<line x1="614.5" y1="116" x2="614.5" stroke="#6B0404" stroke-width="15"/>
+</svg>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -20,7 +20,8 @@ function App() {
             }
           />
           <Route element={<LiarGameLayout />}>
-            <Route path="/liar" element={<LiarMainPage />} />
+            <Route path="/liar/room" element={<LiarMainPage />} />
+            <Route path="/liar/room/:roomId" element={<LiarMainPage />} />
           </Route>
         </Routes>
       </Router>

--- a/frontend/src/components/Footer.tsx
+++ b/frontend/src/components/Footer.tsx
@@ -1,15 +1,20 @@
 import styled from 'styled-components';
 
-const FooterContainer = styled.footer`
+interface FooterProps {
+  color?: string;
+}
+
+const FooterContainer = styled.footer<FooterProps>`
   padding: 50px 0;
   margin-top: auto;
+  color: ${({ color }) => color || '#1b1718'};
   font-size: 14px;
   text-align: center;
 `;
 
-function Footer() {
+function Footer({ color }: FooterProps) {
   return (
-    <FooterContainer>
+    <FooterContainer color={color}>
       © 2025 yujeongran game. All rights reserved.
     </FooterContainer>
   );

--- a/frontend/src/components/common/CharacterRegister.tsx
+++ b/frontend/src/components/common/CharacterRegister.tsx
@@ -1,0 +1,46 @@
+import styled from 'styled-components';
+
+const CharacterRegisterWrap = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const PreviewImg = styled.div`
+  width: 70px;
+  height: 70px;
+  margin: 0 auto;
+  border-radius: 100%;
+  background-color: #fff;
+  overflow: hidden;
+`;
+
+const SelectImg = styled.div`
+  display: flex;
+  justify-content: center;
+  gap: 15px;
+  margin-top: 20px;
+
+  > div {
+    width: 40px;
+    height: 40px;
+    border-radius: 100%;
+    background-color: #fff;
+    overflow: hidden;
+  }
+`;
+
+function CharacterRegister() {
+  return (
+    <CharacterRegisterWrap>
+      <PreviewImg></PreviewImg>
+      <SelectImg>
+        <div />
+        <div />
+        <div />
+        <div />
+      </SelectImg>
+    </CharacterRegisterWrap>
+  );
+}
+
+export default CharacterRegister;

--- a/frontend/src/components/common/CharacterSet.tsx
+++ b/frontend/src/components/common/CharacterSet.tsx
@@ -1,0 +1,56 @@
+import styled from 'styled-components';
+import media from '../../styles/breakPoint';
+import CharacterRegister from './CharacterRegister';
+import NickNameRegister from './NickNameRegister';
+
+const ContTitile = styled.h2`
+  margin-bottom: 20px;
+  text-align: center;
+  font-size: 24px;
+
+  ${media.medium`
+    font-size:20px;
+  `}
+`;
+
+const Cont = styled.div`
+  padding: 34px 40px;
+  border-radius: ${({ theme }) => theme.borderRad};
+  background: ${({ theme }) => theme.subBg};
+
+  ${media.medium`
+    padding: 34px 24px;
+  `}
+`;
+
+const Button = styled.button`
+  width: 100%;
+  height: 40px;
+  margin-top: 20px;
+  color: #fff;
+  font-size: 16px;
+  border-radius: ${({ theme }) => theme.borderRadSm};
+  background: ${({ theme }) => theme.point};
+`;
+
+function CharacterSet({ isGuest }: { isGuest: boolean }) {
+  return (
+    <Cont>
+      <ContTitile>캐릭터 생성</ContTitile>
+      {/* 캐릭터 등록 */}
+      <CharacterRegister />
+      {/* 닉네임 등록 */}
+      <NickNameRegister
+        placeholder={
+          isGuest
+            ? '닉네임을 입력하세요'
+            : '방장은 바로 당신! 멋진 닉네임과 함께 방을 열어보세요.'
+        }
+      />
+
+      <Button>{isGuest ? '게임 참가하기' : '방 만들기'}</Button>
+    </Cont>
+  );
+}
+
+export default CharacterSet;

--- a/frontend/src/components/common/NickNameRegister.tsx
+++ b/frontend/src/components/common/NickNameRegister.tsx
@@ -1,0 +1,53 @@
+import styled from 'styled-components';
+
+const InputBox = styled.div`
+  position: relative;
+  width: 100%;
+  height: 40px;
+  margin-top: 40px;
+  border: 1px solid ${({ theme }) => theme.point};
+  border-radius: ${({ theme }) => theme.borderRadSm};
+  overflow: hidden;
+
+  label {
+    position: absolute;
+    z-index: 1;
+    top: 5px;
+    left: 5px;
+    width: 66px;
+    height: calc(100% - 10px);
+    line-height: 30px;
+    color: #fff;
+    text-align: center;
+    border-radius: ${({ theme }) => theme.borderRadXsm};
+    background-color: ${({ theme }) => theme.point};
+  }
+
+  input {
+    padding-left: 80px;
+    width: 100%;
+    height: 100%;
+    border: 0;
+    background: #fff;
+
+    &::placeholder {
+      color: #ccc;
+    }
+  }
+`;
+
+function NickNameRegister({ placeholder }: { placeholder: string }) {
+  return (
+    <InputBox>
+      <label htmlFor="nickname">닉네임</label>
+      <input
+        id="nickname"
+        type="text"
+        maxLength={10}
+        placeholder={placeholder}
+      />
+    </InputBox>
+  );
+}
+
+export default NickNameRegister;

--- a/frontend/src/components/common/NickNameRegister.tsx
+++ b/frontend/src/components/common/NickNameRegister.tsx
@@ -5,7 +5,7 @@ const InputBox = styled.div`
   width: 100%;
   height: 40px;
   margin-top: 40px;
-  border: 1px solid ${({ theme }) => theme.point};
+  border: 1px solid ${({ theme }) => theme.border};
   border-radius: ${({ theme }) => theme.borderRadSm};
   overflow: hidden;
 
@@ -18,15 +18,17 @@ const InputBox = styled.div`
     height: calc(100% - 10px);
     line-height: 30px;
     color: #fff;
+    font-size: 14px;
     text-align: center;
     border-radius: ${({ theme }) => theme.borderRadXsm};
     background-color: ${({ theme }) => theme.point};
   }
 
   input {
-    padding-left: 80px;
-    width: 100%;
+    width: calc(100% - 94px);
     height: 100%;
+    padding-left: 80px;
+    padding-right: 14px;
     border: 0;
     background: #fff;
 
@@ -43,7 +45,7 @@ function NickNameRegister({ placeholder }: { placeholder: string }) {
       <input
         id="nickname"
         type="text"
-        maxLength={10}
+        maxLength={20}
         placeholder={placeholder}
       />
     </InputBox>

--- a/frontend/src/components/common/gameTitle/LiarGameTitle.tsx
+++ b/frontend/src/components/common/gameTitle/LiarGameTitle.tsx
@@ -1,0 +1,22 @@
+import styled from 'styled-components';
+import media from '../../../styles/breakPoint';
+
+const GameTitle = styled.h1`
+  padding: 70px 0;
+  color: #fff;
+  font-size: 46px;
+  font-family: 'JejuDoldam';
+  text-align: center;
+  text-shadow: 0px 0px 19px rgba(0, 0, 0, 0.35);
+
+  ${media.medium`
+    padding: 50px 0;
+    font-size:36px;
+  `}
+`;
+
+function LiarGameTitle({ title }: { title: string }) {
+  return <GameTitle>{title}</GameTitle>;
+}
+
+export default LiarGameTitle;

--- a/frontend/src/components/layout/LiarGameLayout.tsx
+++ b/frontend/src/components/layout/LiarGameLayout.tsx
@@ -1,11 +1,65 @@
 import { Outlet } from 'react-router-dom';
-import { ThemeProvider } from 'styled-components';
+import styled, { ThemeProvider } from 'styled-components';
+import media from '../../styles/breakPoint';
 import { gameThemes } from '../../styles/gameThemes';
+import LiarGameTitle from '../common/gameTitle/LiarGameTitle';
+import Footer from '../Footer';
+
+const Wrap = styled.div`
+  position: relative;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+  padding: 0 36px;
+  background-color: ${({ theme }) => theme.subPoint};
+  overflow: hidden;
+
+  ${media.medium`
+      padding: 0 24px;
+  `}
+
+  &:before {
+    content: '';
+    position: absolute;
+    z-index: -1;
+    top: 50%;
+    left: 50%;
+    width: 1032px;
+    height: 988px;
+    background: url('/image/gun.svg') no-repeat center;
+    background-size: 100%;
+    transform: translate(-50%, -50%);
+
+    ${media.medium`
+      width: 400px;
+      height: 400px;
+      top:-100px;
+      left:-100px;
+      transform: inherit;
+  `}
+  }
+`;
+
+const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  max-width: 1200px;
+  width: 100%;
+  margin: 0 auto;
+  color: ${({ theme }) => theme.point};
+`;
 
 function LiarGameLayout() {
   return (
     <ThemeProvider theme={gameThemes.liar}>
-      <Outlet />
+      <Wrap>
+        <LiarGameTitle title={'라이어 게임'} />
+        <Container>
+          <Outlet />
+        </Container>
+        <Footer color="#fff" />
+      </Wrap>
     </ThemeProvider>
   );
 }

--- a/frontend/src/components/liar/ContContainer.tsx
+++ b/frontend/src/components/liar/ContContainer.tsx
@@ -1,0 +1,13 @@
+import styled from 'styled-components';
+
+const LiarContainer = styled.div`
+  max-width: 590px;
+  width: 100%;
+  margin: 0 auto;
+`;
+
+function ContContainer({ children }: { children: React.ReactNode }) {
+  return <LiarContainer>{children}</LiarContainer>;
+}
+
+export default ContContainer;

--- a/frontend/src/components/liar/GameRuleList.tsx
+++ b/frontend/src/components/liar/GameRuleList.tsx
@@ -1,0 +1,87 @@
+import media from '../../styles/breakPoint';
+import styled from 'styled-components';
+
+const RuleList = styled.ul`
+  display: flex;
+  max-width: 900px;
+  width: 100%;
+  margin: 100px auto 0;
+  gap: 30px;
+  flex-wrap: wrap;
+
+  ${media.medium`
+    margin:50px auto 0;
+    gap: 15px;
+  `}
+
+  li {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    flex: 1;
+    padding: 36px 20px;
+    text-align: center;
+    border-radius: ${({ theme }) => theme.borderRad};
+    background: ${({ theme }) => theme.subBg};
+
+    ${media.small`
+      flex:auto;
+      width:100%;
+      padding:24px 10px;
+  `}
+
+    div p {
+      font-size: 20px;
+      ${media.medium`
+        font-size:18px;
+      `}
+    }
+
+    div span {
+      display: block;
+      margin-top: 14px;
+      color: ${({ theme }) => theme.subPoint};
+      line-height: 1.5;
+      ${media.medium`
+        font-size:15px;
+      `}
+    }
+  }
+`;
+
+function GameRuleList() {
+  return (
+    <RuleList>
+      <li>
+        <div>
+          <p>라이어를 찾아라</p>
+          <span>
+            누가 진실을 말하고 누가 거짓을
+            <br /> 말하는지 추리하세요.
+          </span>
+        </div>
+      </li>
+      <li>
+        <div>
+          <p>친구들과 함께</p>
+          <span>
+            최대 10명까지 함께
+            <br /> 플레이할 수 있습니다.
+          </span>
+        </div>
+      </li>
+      <li>
+        <div>
+          <p>투표로 결정</p>
+          <span>
+            누가 라이어인지
+            <br />
+            투표로 결정하세요.
+          </span>
+        </div>
+      </li>
+    </RuleList>
+  );
+}
+
+export default GameRuleList;

--- a/frontend/src/pages/liar/LiarMainPage.tsx
+++ b/frontend/src/pages/liar/LiarMainPage.tsx
@@ -1,5 +1,20 @@
+import { useParams } from 'react-router-dom';
+import ContContainer from '../../components/liar/ContContainer';
+import CharacterSet from '../../components/common/CharacterSet';
+import GameRuleList from '../../components/liar/GameRuleList';
+
 function LiarMainPage() {
-  return <></>;
+  const { roomId } = useParams();
+  const isGuest = !!roomId;
+
+  return (
+    <>
+      <ContContainer>
+        <CharacterSet isGuest={isGuest} />
+      </ContContainer>
+      <GameRuleList />
+    </>
+  );
 }
 
 export default LiarMainPage;

--- a/frontend/src/styles/gameThemes.ts
+++ b/frontend/src/styles/gameThemes.ts
@@ -1,13 +1,16 @@
-export type GameType = 'liar';
-
 export const gameThemes = {
   liar: {
     point: '#800000',
+    subPoint: '#6B0404',
+    subBg: '#f7f7f7',
     textBase: '#1B1718',
-    textPoint: '#800000',
-    textSub: '#6B0404',
     textMuted: '#9C9B9B',
     textPlaceholder: '#e6e6e6',
     border: '#eee',
+    borderRad: '10px',
+    borderRadSm: '6px',
+    borderRadXsm: '4px',
   },
 } as const;
+
+export type GameThemeType = typeof gameThemes.liar;

--- a/frontend/src/styles/globalStyle.tsx
+++ b/frontend/src/styles/globalStyle.tsx
@@ -28,6 +28,11 @@ article, aside, details, figcaption, figure,
 footer, header, hgroup, menu, nav, section {
 	display: block;
 }
+
+:focus {
+    outline: 0;
+}
+
 body {
 	color:#1b1718;
 	font-family: 'HakgyoNadeuri';
@@ -49,11 +54,38 @@ table {
 	border-collapse: collapse;
 	border-spacing: 0;
 }
-
 a {
 	text-decoration: none;
 	color:inherit;
 }
+button {
+	padding:0;
+	color: inherit;
+	border: none;
+	outline: inherit;
+	background: none;
+	cursor:pointer;
+	font-family: 'HakgyoNadeuri';
+}
+button,
+html input[type="button"],
+input[type="reset"],
+input[type="submit"] {
+    appearance: none;
+	-webkit-appearance: none;
+    cursor: pointer;
+    *overflow: visible;
+}
+
+input {
+	-webkit-appearance: none;
+	-moz-appearance: none;
+	appearance: none;
+	margin: 0;
+	font-family: 'HakgyoNadeuri';
+	font-size:16px;
+}
+
 `;
 
 export default GlobalStyle;

--- a/frontend/src/types/styled.d.ts
+++ b/frontend/src/types/styled.d.ts
@@ -1,0 +1,6 @@
+import 'styled-components';
+import { GameThemeType } from '../styles/gameThemes';
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends GameThemeType {}
+}


### PR DESCRIPTION
## 📋 Summary

> - #11 
> - closes #11 

호스트/게스트에 따른 닉네임 설정 화면을 구현합니다.
닉네임 설정 UI를 공통 컴포넌트로 분리하고, 사용자 타입에 따라 placeholder 및 버튼 텍스트를 동적으로 렌더링하도록 구현했습니다.

## ✅ Tasks

- ThemeProvider를 활용한 색상 테마 적용
- 사용자 타입에 따라 placeholder, 버튼 텍스트 동적으로 변경
- 반응형 대응

## ✏️ To Reviewer
초기 UI 구조 위주로 작업했으며, 추후 유효성 로직은 별도 PR로 분리 예정입니다.

## 📷 Screenshot

### 닉네임 설정 화면 미리보기
<table style="width:100%; border-collapse: collapse; text-align: center;">
  <tr>
    <th style="border: 1px solid #ddd; padding: 8px;">pc</th>
    <th style="border: 1px solid #ddd; padding: 8px;">mobile</th>
  </tr>
  <tr>
    <td style="border: 1px solid #ddd; padding: 8px;">
      <img src="https://github.com/user-attachments/assets/ac76694d-1dcb-49a1-8c2a-e1b53c21241c" width="300" />
    </td>
    <td style="border: 1px solid #ddd; padding: 8px;">
      <img src="https://github.com/user-attachments/assets/94a2cb6d-2f17-4df3-972c-5bde9c821e58" width="200" />
    </td>
  </tr>
</table>
