### PR TITLE
[#21] 라이어 게임 - 발언 단계 화면 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,6 +5,7 @@ import Home from './pages/HomePage';
 import LiarGameLayout from './components/layout/LiarGameLayout';
 import LiarMainPage from './pages/liar/LiarMainPage';
 import LiarRoomPage from './pages/liar/LiarRoomPage';
+import LiarExplanationPage from './pages/liar/LiarExplanationPage';
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
             <Route path="/liar/room" element={<LiarMainPage />} />
             <Route path="/liar/room/:roomId" element={<LiarMainPage />} />
             <Route path="/liar/lobby" element={<LiarRoomPage />} />
+            <Route path="/liar/explanation" element={<LiarExplanationPage />} />
           </Route>
         </Routes>
       </Router>

--- a/frontend/src/components/liar/Explanation.tsx
+++ b/frontend/src/components/liar/Explanation.tsx
@@ -1,0 +1,67 @@
+import styled from 'styled-components';
+import media from '../../styles/breakPoint';
+import Timer from './Timer';
+
+const ExplanationCon = styled.div`
+  padding: 40px;
+  margin-bottom: 10px;
+  border-radius: ${({ theme }) => theme.borderRad};
+  background: #f7f7f7;
+
+  ${media.medium`
+    padding:30px;
+  `}
+`;
+
+const Speaker = styled.div`
+  text-align: center;
+
+  > p {
+    color: ${({ theme }) => theme.textPoint};
+    font-size: 16px;
+    margin-bottom: 14px;
+  }
+  > strong {
+    font-size: 24px;
+  }
+`;
+
+const WordGuide = styled.div`
+  padding: 12px 0;
+  color: ${({ theme }) => theme.textBase};
+  text-align: center;
+  border-radius: ${({ theme }) => theme.borderRadSm};
+  background-color: #fff;
+
+  span {
+    color: ${({ theme }) => theme.point};
+  }
+`;
+
+const Button = styled.button`
+  width: 100%;
+  height: 50px;
+  margin-top: 10px;
+  color: #fff;
+  font-size: 16px;
+  border-radius: ${({ theme }) => theme.borderRadSm};
+  background: ${({ theme }) => theme.point};
+`;
+
+function Explanation() {
+  return (
+    <ExplanationCon>
+      <Speaker>
+        <p>현재 발언자</p>
+        <strong>귀여운 오리</strong>
+      </Speaker>
+      <Timer />
+      <WordGuide>
+        <span>호랑이</span>에 대해 설명하세요!
+      </WordGuide>
+      <Button>다음 사람에게 넘기기</Button>
+    </ExplanationCon>
+  );
+}
+
+export default Explanation;

--- a/frontend/src/components/liar/GameRuleList.tsx
+++ b/frontend/src/components/liar/GameRuleList.tsx
@@ -32,6 +32,7 @@ const RuleList = styled.ul`
 
     div p {
       font-size: 20px;
+
       ${media.medium`
         font-size:18px;
       `}

--- a/frontend/src/components/liar/StepGuide.tsx
+++ b/frontend/src/components/liar/StepGuide.tsx
@@ -1,0 +1,38 @@
+import styled from 'styled-components';
+
+const GuideBox = styled.div`
+  display: flex;
+  align-items: flex-start;
+  padding: 24px;
+  margin-bottom: 16px;
+  border-radius: ${({ theme }) => theme.borderRad};
+  background: #f7f7f7;
+
+  > span {
+    padding: 6px 10px;
+    margin-right: 20px;
+    color: ${({ theme }) => theme.point};
+    border-radius: 40px;
+    border: 1px solid #d9d9d9;
+    background-color: #f4f2f2;
+  }
+
+  > p {
+    line-height: 1.5;
+  }
+`;
+
+function StepGuide() {
+  return (
+    <GuideBox>
+      <span>발언 단계</span>
+      <p>
+        모두 돌아가며 제시어에 대해 한마디씩 해주세요.
+        <br />
+        너무 티 나게 말하면 라이어가 눈치챌 수도 있어요!
+      </p>
+    </GuideBox>
+  );
+}
+
+export default StepGuide;

--- a/frontend/src/components/liar/StepGuide.tsx
+++ b/frontend/src/components/liar/StepGuide.tsx
@@ -1,4 +1,5 @@
 import styled from 'styled-components';
+import media from '../../styles/breakPoint';
 
 const GuideBox = styled.div`
   display: flex;
@@ -8,13 +9,23 @@ const GuideBox = styled.div`
   border-radius: ${({ theme }) => theme.borderRad};
   background: #f7f7f7;
 
+  ${media.medium`
+      display:block;
+    `}
+
   > span {
+    display: inline-block;
     padding: 6px 10px;
     margin-right: 20px;
+    margin-bottom: 10px;
     color: ${({ theme }) => theme.point};
     border-radius: 40px;
     border: 1px solid #d9d9d9;
     background-color: #f4f2f2;
+
+    ${media.medium`
+      font-size:14px;
+    `}
   }
 
   > p {

--- a/frontend/src/components/liar/Timer.tsx
+++ b/frontend/src/components/liar/Timer.tsx
@@ -1,0 +1,75 @@
+import { useEffect, useState } from 'react';
+import styled from 'styled-components';
+import media from '../../styles/breakPoint';
+
+const TimerWrap = styled.div`
+  position: relative;
+  width: 120px;
+  height: 120px;
+  margin: 40px auto;
+
+  ${media.medium`
+    margin: 26px auto;
+  `}
+`;
+
+const TimeText = styled.div`
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-size: 40px;
+  font-weight: bold;
+`;
+
+const StyledSvg = styled.svg`
+  width: 120px;
+  height: 120px;
+  transform: rotate(-90deg);
+`;
+
+const CircleBg = styled.circle`
+  stroke: #e5e7eb;
+  stroke-width: 12;
+  fill: none;
+`;
+
+const CircleProgress = styled.circle`
+  stroke: ${({ theme }) => theme.point};
+  stroke-width: 12;
+  fill: none;
+  stroke-dasharray: 283;
+  stroke-dashoffset: 141.5;
+  stroke-linecap: round;
+`;
+
+function Timer() {
+  const radius = 45;
+  const center = 60;
+
+  const [time, setTime] = useState(10);
+
+  useEffect(() => {
+    const timer = setInterval(() => {
+      setTime((prev) => {
+        if (prev <= 1) {
+          clearInterval(timer);
+          return 0;
+        }
+        return prev - 1;
+      });
+    }, 1000);
+  }, []);
+
+  return (
+    <TimerWrap>
+      <StyledSvg>
+        <CircleBg r={radius} cx={center} cy={center} />
+        <CircleProgress r={radius} cx={center} cy={center} />
+      </StyledSvg>
+      <TimeText>{time}</TimeText>
+    </TimerWrap>
+  );
+}
+
+export default Timer;

--- a/frontend/src/pages/liar/LiarExplanationPage.tsx
+++ b/frontend/src/pages/liar/LiarExplanationPage.tsx
@@ -1,0 +1,33 @@
+import styled from 'styled-components';
+import ContContainer from '../../components/liar/ContContainer';
+import StepGuide from '../../components/liar/StepGuide';
+import { AiOutlineInfoCircle } from 'react-icons/ai';
+
+const InfoText = styled.div`
+  display: flex;
+  justify-content: space-between;
+  color: #fff;
+  font-size: 14px;
+
+  p svg {
+    margin-right: 6px;
+    vertical-align: top;
+  }
+`;
+
+function LiarExplanationPage() {
+  return (
+    <ContContainer>
+      <StepGuide />
+      <InfoText>
+        <p>
+          <AiOutlineInfoCircle />
+          10초 후에는 자동으로 다음 사람에게 넘어갑니다.
+        </p>
+        <p>플레이어 1/10</p>
+      </InfoText>
+    </ContContainer>
+  );
+}
+
+export default LiarExplanationPage;

--- a/frontend/src/pages/liar/LiarExplanationPage.tsx
+++ b/frontend/src/pages/liar/LiarExplanationPage.tsx
@@ -1,13 +1,24 @@
 import styled from 'styled-components';
+import media from '../../styles/breakPoint';
 import ContContainer from '../../components/liar/ContContainer';
 import StepGuide from '../../components/liar/StepGuide';
 import { AiOutlineInfoCircle } from 'react-icons/ai';
+import Explanation from '../../components/liar/Explanation';
 
 const InfoText = styled.div`
   display: flex;
   justify-content: space-between;
   color: #fff;
   font-size: 14px;
+
+  ${media.medium`
+    display: block;
+    margin-top:20px;
+
+    p {
+      margin-top:10px;
+    }
+  `}
 
   p svg {
     margin-right: 6px;
@@ -19,6 +30,7 @@ function LiarExplanationPage() {
   return (
     <ContContainer>
       <StepGuide />
+      <Explanation />
       <InfoText>
         <p>
           <AiOutlineInfoCircle />

--- a/frontend/src/styles/gameThemes.ts
+++ b/frontend/src/styles/gameThemes.ts
@@ -5,6 +5,7 @@ export const gameThemes = {
     subBg: '#f7f7f7',
     textBase: '#1B1718',
     textMuted: '#9C9B9B',
+    textPoint: '#982B1C',
     textPlaceholder: '#e6e6e6',
     border: '#eee',
     borderRad: '10px',


### PR DESCRIPTION
## 📋 Summary

> - #21 
> - closes #21 

라이어 게임의 발언 단계 화면 UI를 구현했습니다.

## ✅ Tasks

- 0초에서 멈추는 카운트다운 타이머 구현
- 원형 프로그레스바 UI 구성

## 📷 Screenshot
<table style="width:100%; border-collapse: collapse; text-align: center;">
  <tr>
    <th style="border: 1px solid #ddd; padding: 8px;">pc</th>
    <th style="border: 1px solid #ddd; padding: 8px;">mobile</th>
  </tr>
  <tr>
    <td style="border: 1px solid #ddd; padding: 8px;">
      <img src="https://github.com/user-attachments/assets/af179394-c2fc-44ad-92f9-7ed51dad1645" width="400" />
    </td>
    <td style="border: 1px solid #ddd; padding: 8px;">
      <img src="https://github.com/user-attachments/assets/a91d214e-b9cd-4d79-b1fd-edbe5c717a05" width="180" />
    </td>
  </tr>
</table>

