### PR TITLE
[#22] 동전 진실 게임 - 동전 진실 게임 관련 기능 구현

### DIFF
--- a/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
@@ -25,7 +25,8 @@ public class SecurityConfig {
                         ).permitAll()
                         .requestMatchers(
                                 "/liar/**",
-                                "/balance/**"
+                                "/balance/**",
+                                "/coin/**"
                         ).permitAll()
                         // 그 외에는 인증 필요
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/controller/CoinGameController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/controller/CoinGameController.java
@@ -1,0 +1,94 @@
+package com.mallan.yujeongran.icebreaking.coin_game.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinSubmitAnswerRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinSubmitQuestionRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinFinalResultListResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinQuestionResultResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.service.CoinGameService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/coin/game")
+@RequiredArgsConstructor
+@Tag(name = "Coin Game API", description = "코인 진실 게임 진행 관련 API")
+public class CoinGameController {
+
+    private final CoinGameService coinGameService;
+    private final RedisTemplate redisTemplate;
+
+    @PostMapping("/{roomCode}/question")
+    @Operation(summary = "질문 작성 API", description = "질문과 예측을 입력하여 제출합니다.")
+    public ResponseEntity<CommonResponse<Void>> submitQuestion(
+            @PathVariable String roomCode,
+            @RequestBody CoinSubmitQuestionRequestDto request
+    ) {
+        coinGameService.submitQuestion(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("질문 제출 완료", null));
+    }
+
+    @PostMapping("/{roomCode}/answer")
+    @Operation(summary = "답변 제출 API", description = "질문에 따른 답변을 제출합니다.(YES/NO)")
+    public ResponseEntity<CommonResponse<Object>> submitAnswer(
+            @PathVariable String roomCode,
+            @RequestBody CoinSubmitAnswerRequestDto request
+    ) {
+        coinGameService.submitAnswer(roomCode, request);
+
+        if (coinGameService.isAllAnswersSubmitted(roomCode)) {
+            var result = coinGameService.completeQuestionAndReturnResult(roomCode);
+            return ResponseEntity.ok(CommonResponse.success("답변 및 결과 처리 완료", result));
+        }
+
+        return ResponseEntity.ok(CommonResponse.success("답변 제출 완료", null));
+    }
+
+    @GetMapping("/{roomCode}/question/result")
+    @Operation(summary = "질문 결과 확인 API", description = "모든 답변이 제출되면 결과를 반환합니다.")
+    public ResponseEntity<CommonResponse<CoinQuestionResultResponseDto>> getQuestionResult(
+            @PathVariable String roomCode
+    ) {
+        String resultKey = "coin:room:" + roomCode + ":lastResult";
+
+        CoinQuestionResultResponseDto result = (CoinQuestionResultResponseDto) redisTemplate.opsForValue().get(resultKey);
+        if (result == null) {
+            return ResponseEntity.ok(CommonResponse.success("아직 결과가 준비되지 않았습니다.", null));
+        }
+
+        return ResponseEntity.ok(CommonResponse.success("질문 결과 반환 성공", result));
+    }
+
+    @GetMapping("/{roomCode}/result")
+    @Operation(summary = "최종 결과 반환 API", description = "최종 결과를 반환합니다.")
+    public ResponseEntity<CommonResponse<CoinFinalResultListResponseDto>> getFinalResults(
+            @PathVariable String roomCode
+    ) {
+        var result = coinGameService.getFinalResults(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("최종 결과 반환 성공", result));
+    }
+
+    @PostMapping("/{roomCode}/restart")
+    @Operation(summary = "게임 재시작 API", description = "질문/답변/점수를 초기화하고 게임을 다시 시작합니다.")
+    public ResponseEntity<CommonResponse<Void>> restartGame(
+            @PathVariable String roomCode
+    ) {
+        coinGameService.restartGame(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("게임이 재시작되었습니다.", null));
+    }
+
+    @PostMapping("/{roomCode}/end")
+    @Operation(summary = "게임 종료 API", description = "방 및 관련 데이터를 모두 삭제합니다.")
+    public ResponseEntity<CommonResponse<Void>> endGame(
+            @PathVariable String roomCode
+    ) {
+        coinGameService.endGame(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("게임이 종료되었습니다.", null));
+    }
+
+}
+

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/controller/CoinRoomController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/controller/CoinRoomController.java
@@ -1,0 +1,82 @@
+package com.mallan.yujeongran.icebreaking.coin_game.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.*;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinCreateRoomResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinJoinRoomResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinWaitingRoomResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.service.CoinPlayerService;
+import com.mallan.yujeongran.icebreaking.coin_game.service.CoinRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/coin/room")
+@RequiredArgsConstructor
+@Tag(name = "Coin Room API", description = "코인 진실 게임 방 관련 API")
+public class CoinRoomController {
+
+    private final CoinRoomService coinRoomService;
+    private final CoinPlayerService coinPlayerService;
+
+    @PostMapping
+    @Operation(summary = "방 생성 API", description = "닉네임과 프로필 이미지는 입력받아 방을 생성합니다.")
+    public ResponseEntity<CommonResponse<CoinCreateRoomResponseDto>> createRoom(
+            @RequestBody CoinCreateRoomRequestDto request
+    ){
+        CoinCreateRoomResponseDto response = coinPlayerService.createRoom(request);
+        return ResponseEntity.ok(CommonResponse.success("방 생성 성공!", response));
+    }
+
+    @PostMapping("/{roomCode}/join")
+    @Operation(summary = "방 참가 API", description = "닉네임과 프로필 이미지를 입력받아 방에 참가합니다.")
+    public ResponseEntity<CommonResponse<CoinJoinRoomResponseDto>> joinRoom(
+            @PathVariable String roomCode,
+            @RequestBody CoinJoinRoomRequestDto request
+    ){
+        CoinJoinRoomResponseDto response = coinPlayerService.joinRoom(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("방 입장 성공!", response));
+    }
+
+    @GetMapping("/{roomCode}/ready")
+    @Operation(summary = "대기방 정보 조회 API", description = "방장, 참가자, 라운드 수 등의 대기방 정보를 반환합니다.")
+    public ResponseEntity<CommonResponse<CoinWaitingRoomResponseDto>> getWaitingRoomInfo(
+            @PathVariable String roomCode
+    ) {
+        CoinWaitingRoomResponseDto response = coinRoomService.getWaitingRoomInfo(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("대기방 정보 반환 성공", response));
+    }
+
+    @PatchMapping("/{roomCode}/round")
+    @Operation(summary = "라운드 수 설정", description = "방장이 라운드 수를 설정합니다.")
+    public ResponseEntity<CommonResponse<String>> setRound(
+            @PathVariable String roomCode,
+            @RequestBody CoinSetRoundRequestDto request
+    ) {
+        coinRoomService.setRound(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("라운드 수 설정 성공!", null));
+    }
+
+    @PostMapping("/{roomCode}/start")
+    @Operation(summary = "게임 시작", description = "방장이 게임을 시작합니다.")
+    public ResponseEntity<CommonResponse<String>> startGame(
+            @PathVariable String roomCode,
+            @RequestBody CoinStartGameRequestDto request
+    ) {
+        coinRoomService.startGame(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("게임 시작 성공!", null));
+    }
+
+    @PostMapping("/{roomCode}/leave/{playerId}")
+    @Operation(summary = "방 나가기", description = "플레이어가 방을 나가고, 남은 인원이 없으면 방도 삭제됩니다.")
+    public ResponseEntity<CommonResponse<Void>> leaveRoom(
+            @PathVariable String roomCode,
+            @RequestBody CoinExitRoomRequestDto request) {
+        coinRoomService.leaveRoom(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("방을 나갔습니다.", null));
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinCreateRoomRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinCreateRoomRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinCreateRoomRequestDto {
+
+    @Schema(description = "닉네임", example = "Noah")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지", example = "avatar_1_140x140.png")
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinExitRoomRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinExitRoomRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinExitRoomRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "m310lam5")
+    private String playerId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinJoinRoomRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinJoinRoomRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinJoinRoomRequestDto {
+
+    @Schema(description = "닉네임", example = "guest_1")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지", example = "avatar_2_140x140.png")
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinSetRoundRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinSetRoundRequestDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinSetRoundRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "n14k5ua0")
+    private String playerId;
+
+    @Schema(description = "게임 라운드", example = "3")
+    private int roundCount;
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinStartGameRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinStartGameRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinStartGameRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "lk3n251p")
+    private String playerId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinSubmitAnswerRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinSubmitAnswerRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinSubmitAnswerRequestDto {
+
+    @Schema(description = "플레이어 ID", example = "z9y8x7w6")
+    private String playerId;
+
+    @Schema(description = "답변 (YES/NO)", example = "YES")
+    private String answer;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinSubmitQuestionRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/request/CoinSubmitQuestionRequestDto.java
@@ -1,0 +1,18 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CoinSubmitQuestionRequestDto {
+
+    @Schema(description = "플레이어 ID", example = "a1b2c3d4")
+    private String playerId;
+
+    @Schema(description = "질문 내용", example = "나는 오늘 아침을 먹었다!")
+    private String question;
+
+    @Schema(description = "예상 YES 인원 수", example = "2")
+    private int expectedYesCount;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinCreateRoomResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinCreateRoomResponseDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoinCreateRoomResponseDto {
+
+    private String roomCode;
+    private String hostId;
+    private String hostNickname;
+    private String url;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinFinalResultListResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinFinalResultListResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoinFinalResultListResponseDto {
+
+    private List<CoinFinalResultResponseDto> results;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinFinalResultResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinFinalResultResponseDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoinFinalResultResponseDto {
+
+    private String playerId;
+    private String nickname;
+    private String profileImage;
+    private int score;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinJoinRoomResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinJoinRoomResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoinJoinRoomResponseDto {
+
+    private String playerId;
+    private String nickname;
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinQuestionResultResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinQuestionResultResponseDto.java
@@ -1,0 +1,16 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoinQuestionResultResponseDto {
+
+    private int yesCount;
+    private int noCount;
+    private int expectedYesCount;
+    private boolean isCorrect;
+    private int scoreAwarded;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinWaitingPlayerResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinWaitingPlayerResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CoinWaitingPlayerResponseDto {
+
+    private String playerId;
+    private String nickname;
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinWaitingRoomResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/dto/response/CoinWaitingRoomResponseDto.java
@@ -1,0 +1,18 @@
+package com.mallan.yujeongran.icebreaking.coin_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class CoinWaitingRoomResponseDto {
+
+    private String roomCode;
+    private String hostId;
+    private String hostNickname;
+    private int roundCount;
+    private List<CoinWaitingPlayerResponseDto> players;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinAnswer.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinAnswer.java
@@ -1,0 +1,37 @@
+package com.mallan.yujeongran.icebreaking.coin_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coin_answer")
+@Builder
+public class CoinAnswer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "question_id", nullable = false)
+    private long questionId;
+
+    @Column(name= "player_id", nullable = false)
+    private String playerId;
+
+    @Column(name = "answer", nullable = false)
+    private String answer;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated(){
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinFinalResult.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinFinalResult.java
@@ -1,0 +1,44 @@
+package com.mallan.yujeongran.icebreaking.coin_game.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coin_final_result")
+@Builder
+public class CoinFinalResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_code", nullable = false)
+    private String roomCode;
+
+    @Column(name = "player_id", nullable = false)
+    private String playerId;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "score", nullable = false)
+    private int score;
+
+    @Column(name = "profileImage", nullable = false)
+    private String profileImage;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinPlayer.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinPlayer.java
@@ -1,0 +1,36 @@
+package com.mallan.yujeongran.icebreaking.coin_game.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coin_player")
+public class CoinPlayer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "player_id", nullable = false)
+    private String playerId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated(){
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinQuestion.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinQuestion.java
@@ -1,0 +1,34 @@
+package com.mallan.yujeongran.icebreaking.coin_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coin_question")
+@Builder
+public class CoinQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "question", nullable = false, length = 200)
+    private String question;
+
+    @Column(name = "expected_count", nullable = false)
+    private int expectedCount;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinQuestionResult.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinQuestionResult.java
@@ -1,0 +1,31 @@
+package com.mallan.yujeongran.icebreaking.coin_game.entity;
+
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coin_question_result")
+@Builder
+public class CoinQuestionResult {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private long id;
+
+    @Column(name = "question_id", nullable = false)
+    private Long questionId;
+
+    @Column(name = "yes_count", nullable = false)
+    private int yesCount;
+
+    @Column(name = "no_count", nullable = false)
+    private int noCount;
+
+    @Column(name = "is_correct", nullable = false)
+    private boolean isCorrect;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinRoom.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/entity/CoinRoom.java
@@ -1,0 +1,43 @@
+package com.mallan.yujeongran.icebreaking.coin_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "coin_room")
+@Builder
+public class CoinRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_code", nullable = false)
+    private String roomCode;
+
+    @Column(name = "host_id", nullable = false)
+    private String hostId;
+
+    @Column(name = "host_nickname", nullable = false)
+    private String hostNickname;
+
+    @Column(name = "round_count", nullable = false)
+    private int roundCount;
+
+    @Column(name = "player_count", nullable = false)
+    private int playerCount;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinAnswerRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinAnswerRepository.java
@@ -1,0 +1,11 @@
+package com.mallan.yujeongran.icebreaking.coin_game.repository;
+
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoinAnswerRepository extends JpaRepository<CoinAnswer, Long> {
+
+    List<CoinAnswer> findByQuestionId(Long questionId);
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinFinalResultRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinFinalResultRepository.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.coin_game.repository;
+
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinFinalResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface CoinFinalResultRepository extends JpaRepository<CoinFinalResult, Long> {
+
+    List<CoinFinalResult> findByRoomCodeOrderByScoreDesc(String roomCode);
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinQuestionRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinQuestionRepository.java
@@ -1,0 +1,10 @@
+package com.mallan.yujeongran.icebreaking.coin_game.repository;
+
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoinQuestionRepository extends JpaRepository<CoinQuestion, Long> {
+
+
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinQuestionResultRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinQuestionResultRepository.java
@@ -1,0 +1,7 @@
+package com.mallan.yujeongran.icebreaking.coin_game.repository;
+
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinQuestionResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoinQuestionResultRepository extends JpaRepository<CoinQuestionResult, Long> {
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinRoomRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/repository/CoinRoomRepository.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.coin_game.repository;
+
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CoinRoomRepository extends JpaRepository<CoinRoom, Long> {
+
+    Optional<CoinRoom> findByRoomCode(String roomCode);
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinGameService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinGameService.java
@@ -1,0 +1,202 @@
+package com.mallan.yujeongran.icebreaking.coin_game.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinSubmitAnswerRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinSubmitQuestionRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinFinalResultListResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinFinalResultResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinQuestionResultResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinAnswer;
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinFinalResult;
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinQuestion;
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinQuestionResult;
+import com.mallan.yujeongran.icebreaking.coin_game.repository.*;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CoinGameService {
+
+    private final ObjectMapper objectMapper;
+    private final RedisTemplate<String, String> redisTemplate;
+    private final CoinQuestionRepository coinQuestionRepository;
+    private final CoinAnswerRepository coinAnswerRepository;
+    private final CoinQuestionResultRepository coinQuestionResultRepository;
+    private final CoinFinalResultRepository coinFinalResultRepository;
+    private final CoinRoomRepository coinRoomRepository;
+
+    public void submitQuestion(String roomCode, CoinSubmitQuestionRequestDto request) {
+        CoinQuestion question = CoinQuestion.builder()
+                .question(request.getQuestion())
+                .expectedCount(request.getExpectedYesCount())
+                .createdAt(LocalDateTime.now())
+                .build();
+        coinQuestionRepository.save(question);
+
+        redisTemplate.opsForValue().set("coin:room:" + roomCode + ":currentQuestionId", question.getId().toString());
+        redisTemplate.opsForValue().set("coin:room:" + roomCode + ":currentQuestionOwner", request.getPlayerId());
+    }
+
+    public void submitAnswer(String roomCode, CoinSubmitAnswerRequestDto request) {
+        String questionId = redisTemplate.opsForValue().get("coin:room:" + roomCode + ":currentQuestionId");
+
+        CoinAnswer answer = CoinAnswer.builder()
+                .questionId(Long.parseLong(questionId))
+                .playerId(request.getPlayerId())
+                .answer(request.getAnswer())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        coinAnswerRepository.save(answer);
+
+        redisTemplate.opsForList().rightPush("coin:room:" + roomCode + ":currentAnswers", request.getPlayerId());
+    }
+
+    public boolean isAllAnswersSubmitted(String roomCode) {
+        String questionOwner = redisTemplate.opsForValue().get("coin:room:" + roomCode + ":currentQuestionOwner");
+
+        List<String> allPlayers = redisTemplate.opsForList().range("coin:room:" + roomCode + ":players", 0, -1);
+        List<String> answeredPlayers = redisTemplate.opsForList().range("coin:room:" + roomCode + ":currentAnswers", 0, -1);
+
+        long expectedAnswers = allPlayers.stream().filter(id -> !id.equals(questionOwner)).count();
+        return answeredPlayers != null && answeredPlayers.size() >= expectedAnswers;
+    }
+
+    public CoinQuestionResultResponseDto completeQuestionAndReturnResult(String roomCode) {
+        String resultKey = "coin:room:" + roomCode + ":lastResult";
+
+        try {
+            String resultJson = redisTemplate.opsForValue().get(resultKey);
+            if (resultJson != null) {
+                return objectMapper.readValue(resultJson, CoinQuestionResultResponseDto.class);
+            }
+
+            Long questionId = Long.parseLong(redisTemplate.opsForValue().get("coin:room:" + roomCode + ":currentQuestionId"));
+            String questionOwner = redisTemplate.opsForValue().get("coin:room:" + roomCode + ":currentQuestionOwner");
+
+            List<CoinAnswer> answers = coinAnswerRepository.findByQuestionId(questionId);
+
+            long yesCount = answers.stream().filter(a -> a.getAnswer().equalsIgnoreCase("YES")).count();
+            long noCount = answers.size() - yesCount;
+
+            CoinQuestion question = coinQuestionRepository.findById(questionId).orElseThrow();
+            boolean isCorrect = (int) yesCount == question.getExpectedCount();
+
+            CoinQuestionResult result = CoinQuestionResult.builder()
+                    .questionId(questionId)
+                    .yesCount((int) yesCount)
+                    .noCount((int) noCount)
+                    .isCorrect(isCorrect)
+                    .build();
+            coinQuestionResultRepository.save(result);
+
+            int scoreAwarded = 0;
+            if (isCorrect) {
+                redisTemplate.opsForValue().increment("coin:room:" + roomCode + ":score:" + questionOwner);
+                scoreAwarded = 1;
+            }
+
+            CoinQuestionResultResponseDto responseDto = CoinQuestionResultResponseDto.builder()
+                    .yesCount((int) yesCount)
+                    .noCount((int) noCount)
+                    .expectedYesCount(question.getExpectedCount())
+                    .isCorrect(isCorrect)
+                    .scoreAwarded(scoreAwarded)
+                    .build();
+
+            String json = objectMapper.writeValueAsString(responseDto);
+            redisTemplate.opsForValue().set(resultKey, json);
+
+            redisTemplate.delete("coin:room:" + roomCode + ":currentAnswers");
+            redisTemplate.delete("coin:room:" + roomCode + ":currentQuestionId");
+            redisTemplate.delete("coin:room:" + roomCode + ":currentQuestionOwner");
+
+            return responseDto;
+
+        } catch (Exception e) {
+            throw new RuntimeException("질문 결과 생성 중 오류 발생", e);
+        }
+    }
+
+    public CoinFinalResultListResponseDto getFinalResults(String roomCode) {
+        List<String> playerIds = redisTemplate.opsForList().range("coin:room:" + roomCode + ":players", 0, -1);
+
+        List<CoinFinalResultResponseDto> results = playerIds.stream().map(playerId -> {
+            String nickname = redisTemplate.opsForValue().get("coin:player:" + playerId + ":nickname");
+            String profileImage = redisTemplate.opsForValue().get("coin:player:" + playerId + ":profileImage");
+            String scoreStr = redisTemplate.opsForValue().get("coin:room:" + roomCode + ":score:" + playerId);
+            int score = scoreStr == null ? 0 : Integer.parseInt(scoreStr);
+
+            CoinFinalResult finalResult = CoinFinalResult.builder()
+                    .roomCode(roomCode)
+                    .playerId(playerId)
+                    .nickname(nickname)
+                    .score(score)
+                    .profileImage(profileImage)
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            coinFinalResultRepository.save(finalResult);
+
+            return CoinFinalResultResponseDto.builder()
+                    .playerId(playerId)
+                    .nickname(nickname)
+                    .score(score)
+                    .profileImage(profileImage)
+                    .build();
+        }).sorted((a, b) -> b.getScore() - a.getScore()).toList();
+
+        return CoinFinalResultListResponseDto.builder()
+                .results(results)
+                .build();
+    }
+
+    public void restartGame(String roomCode) {
+        redisTemplate.delete("coin:room:" + roomCode + ":currentQuestionId");
+        redisTemplate.delete("coin:room:" + roomCode + ":currentQuestionOwner");
+        redisTemplate.delete("coin:room:" + roomCode + ":currentAnswers");
+
+        redisTemplate.delete("coin:room:" + roomCode + ":lastResult");
+
+        List<String> players = redisTemplate.opsForList().range("coin:room:" + roomCode + ":players", 0, -1);
+        if (players != null) {
+            for (String playerId : players) {
+                redisTemplate.delete("coin:room:" + roomCode + ":score:" + playerId);
+            }
+        }
+    }
+
+    public void endGame(String roomCode) {
+        List<String> players = redisTemplate.opsForList().range("coin:room:" + roomCode + ":players", 0, -1);
+        if (players != null) {
+            for (String playerId : players) {
+                redisTemplate.delete("coin:player:" + playerId + ":nickname");
+                redisTemplate.delete("coin:player:" + playerId + ":profileImage");
+                redisTemplate.delete("coin:room:" + roomCode + ":score:" + playerId);
+            }
+        }
+
+        redisTemplate.delete("coin:room:" + roomCode + ":lastResult");
+
+        redisTemplate.delete("coin:room:" + roomCode);
+        redisTemplate.delete("coin:room:" + roomCode + ":players");
+        redisTemplate.delete("coin:room:" + roomCode + ":currentQuestionId");
+        redisTemplate.delete("coin:room:" + roomCode + ":currentQuestionOwner");
+        redisTemplate.delete("coin:room:" + roomCode + ":currentAnswers");
+
+        coinFinalResultRepository.deleteAll(coinFinalResultRepository.findByRoomCodeOrderByScoreDesc(roomCode));
+        coinQuestionResultRepository.deleteAll();
+        coinAnswerRepository.deleteAll();
+        coinQuestionRepository.deleteAll();
+        coinRoomRepository.findByRoomCode(roomCode).ifPresent(coinRoomRepository::delete);
+    }
+
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinPlayerService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinPlayerService.java
@@ -1,0 +1,92 @@
+package com.mallan.yujeongran.icebreaking.coin_game.service;
+
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinCreateRoomRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinJoinRoomRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinCreateRoomResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinJoinRoomResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinRoom;
+import com.mallan.yujeongran.icebreaking.coin_game.repository.CoinRoomRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class CoinPlayerService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final CoinRoomRepository coinRoomRepository;
+
+    @Value("${COIN_ROOM_BASE_URL}")
+    private String coinRoomBaseUrl;
+
+    public CoinCreateRoomResponseDto createRoom(CoinCreateRoomRequestDto request){
+        String playerId = UUID.randomUUID().toString().replace("-","").substring(0, 8);
+        String roomCode = UUID.randomUUID().toString().replace("-","").substring(0, 8);
+        redisTemplate.opsForValue().set("coin:player:" + playerId + ":nickname", request.getNickname());
+        redisTemplate.opsForValue().set("coin:player:" + playerId + ":profileImage", request.getProfileImage());
+        redisTemplate.expire("coin:player:" + playerId + ":nickname", Duration.ofHours(24));
+        redisTemplate.expire("coin:player:" + playerId + ":profileImage", Duration.ofHours(24));
+
+        redisTemplate.opsForHash().put("coin:room:" + roomCode, "hostId", playerId);
+        redisTemplate.opsForList().rightPush("coin:room:" + roomCode + ":players", playerId);
+        redisTemplate.expire("coin:room:" + roomCode, Duration.ofHours(24));
+        redisTemplate.expire("coin:room:" + roomCode + ":players", Duration.ofHours(24));
+
+        CoinRoom room = CoinRoom.builder()
+                .roomCode(roomCode)
+                .hostId(playerId)
+                .hostNickname(request.getNickname())
+                .roundCount(3)
+                .playerCount(1)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+
+        coinRoomRepository.save(room);
+
+        return CoinCreateRoomResponseDto.builder()
+                .roomCode(roomCode)
+                .hostId(playerId)
+                .hostNickname(request.getNickname())
+                .url(coinRoomBaseUrl + "/coin/" + roomCode)
+                .build();
+    }
+
+    public CoinJoinRoomResponseDto joinRoom(String roomCode, CoinJoinRoomRequestDto request) {
+        Boolean exists = redisTemplate.hasKey("coin:room:" + roomCode);
+        if (exists == null || !exists) {
+            throw new IllegalArgumentException("해당 방이 존재하지 않습니다.");
+        }
+
+        String playerId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+
+        redisTemplate.opsForValue().set("coin:player:" + playerId + ":nickname", request.getNickname());
+        redisTemplate.opsForValue().set("coin:player:" + playerId + ":profileImage", request.getProfileImage());
+        redisTemplate.expire("coin:player:" + playerId + ":nickname", Duration.ofHours(24));
+        redisTemplate.expire("coin:player:" + playerId + ":profileImage", Duration.ofHours(24));
+
+        redisTemplate.opsForList().rightPush("coin:room:" + roomCode + ":players", playerId);
+
+        coinRoomRepository.findByRoomCode(roomCode).ifPresent(room -> {
+            int current = room.getPlayerCount();
+            room.setPlayerCount(current + 1);
+            coinRoomRepository.save(room);
+        });
+
+        return CoinJoinRoomResponseDto.builder()
+                .playerId(playerId)
+                .nickname(request.getNickname())
+                .profileImage(request.getProfileImage())
+                .build();
+    }
+
+}
+

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinRoomService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinRoomService.java
@@ -1,0 +1,93 @@
+package com.mallan.yujeongran.icebreaking.coin_game.service;
+
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinExitRoomRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinSetRoundRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinStartGameRequestDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinWaitingPlayerResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinWaitingRoomResponseDto;
+import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinRoom;
+import com.mallan.yujeongran.icebreaking.coin_game.repository.CoinRoomRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class CoinRoomService {
+
+    private final CoinGameService coinGameService;
+    private final CoinRoomRepository coinRoomRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public CoinWaitingRoomResponseDto getWaitingRoomInfo(String roomCode) {
+        CoinRoom room = coinRoomRepository.findByRoomCode(roomCode)
+                .orElseThrow(() -> new IllegalArgumentException("해당 방이 존재하지 않습니다."));
+
+        List<String> playerIds = redisTemplate.opsForList().range("coin:room:" + roomCode + ":players", 0, -1);
+        List<CoinWaitingPlayerResponseDto> players = playerIds.stream().map(playerId -> {
+            String nickname = redisTemplate.opsForValue().get("coin:player:" + playerId + ":nickname");
+            String profileImage = redisTemplate.opsForValue().get("coin:player:" + playerId + ":profileImage");
+            return CoinWaitingPlayerResponseDto.builder()
+                    .playerId(playerId)
+                    .nickname(nickname)
+                    .profileImage(profileImage)
+                    .build();
+        }).toList();
+
+        return CoinWaitingRoomResponseDto.builder()
+                .roomCode(room.getRoomCode())
+                .hostId(room.getHostId())
+                .hostNickname(room.getHostNickname())
+                .roundCount(room.getRoundCount())
+                .players(players)
+                .build();
+    }
+
+    public void setRound(String roomCode, CoinSetRoundRequestDto request) {
+        String hostId = (String) redisTemplate.opsForHash().get("coin:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 라운드를 설정할 수 있습니다.");
+        }
+
+        redisTemplate.opsForHash().put("coin:room:" + roomCode, "roundCount", String.valueOf(request.getRoundCount()));
+
+        CoinRoom room = coinRoomRepository.findByRoomCode(roomCode)
+                .orElseThrow(() -> new IllegalArgumentException("해당 방이 존재하지 않습니다."));
+        room.setRoundCount(request.getRoundCount());
+        coinRoomRepository.save(room);
+    }
+
+    public void startGame(String roomCode, CoinStartGameRequestDto request) {
+        String hostId = (String) redisTemplate.opsForHash().get("coin:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 게임을 시작할 수 있습니다.");
+        }
+
+        redisTemplate.opsForValue().set("coin:room:" + roomCode + ":started", "true", Duration.ofHours(24));
+    }
+    public void leaveRoom(String roomCode, CoinExitRoomRequestDto request) {
+        redisTemplate.opsForList().remove("coin:room:" + roomCode + ":players", 1, request.getPlayerId());
+        redisTemplate.delete("coin:player:" + request.getPlayerId() + ":nickname");
+        redisTemplate.delete("coin:player:" + request.getPlayerId() + ":profileImage");
+        redisTemplate.delete("coin:room:" + roomCode + ":score:" + request.getPlayerId());
+
+        coinRoomRepository.findByRoomCode(roomCode).ifPresent(room -> {
+            int current = room.getPlayerCount();
+            room.setPlayerCount(Math.max(0, current - 1));
+            coinRoomRepository.save(room);
+
+            if (room.getPlayerCount() == 0) {
+                coinGameService.endGame(roomCode);
+            }
+        });
+    }
+
+
+}


### PR DESCRIPTION
## 📋 Summary

> - closes #22 
**동전 진실 게임 관련 기능들을 구현합니다.**

## ✅ Tasks

- 호스트 사용자의 방/사용지 생성 및 입장 기능
- 게스트 사용자의 사용자 생성 및 입장 기능
- 사용자의 방 퇴장 기능
- 호스트 사용자의 방 설정 기능
- 호스트 사용자의 게임 시작 기능
- (게임 진행) 질문 생성 기능
- (게임 진행) 질문에 답변 기능
- (게임 진행) 질문 제출 후 해당 질문에 대햔 결과 반환 기능
- (게임 진행) 최종 결과 반환 기능
- (게임 진행) 게임 다시 시작 및 종료 기능

## ✏️ To Reviewer

동전 진실 게임에 관한 기능들을 구현합니다.
사용자 시나리오를 정의하고 정의한 시나리오에 필요하다고 판단되는 기능들을 구현하였습니다.
Swagger를 통해 기능 테스트를 마쳤습니다.

## 📷 Screenshot

<img width="1161" alt="스크린샷 2025-05-25 오후 5 44 38" src="https://github.com/user-attachments/assets/6960b284-25ed-4d00-9f90-23458c2ef058" />
