### PR TITLE
[#25] 오픈 퀘스천 뽑기 게임 - 전체 기능 구현

### DIFF
--- a/backend/src/main/java/com/mallan/yujeongran/MallanApplication.java
+++ b/backend/src/main/java/com/mallan/yujeongran/MallanApplication.java
@@ -2,8 +2,10 @@ package com.mallan.yujeongran;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class MallanApplication {
     public static void main(String[] args) {
         SpringApplication.run(MallanApplication.class, args);

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/controller/QuestionGameController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/controller/QuestionGameController.java
@@ -1,0 +1,127 @@
+package com.mallan.yujeongran.icebreaking.question_game.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionEndGameRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionRestartGameRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionSelectAnswererRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionSubmitAnswerRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.QuestionCurrentQuestionStateResponseDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.QuestionDrawResponseDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.QuestionPlayerRoleResponseDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.QuestionSelectablePlayerListResponseDto;
+import com.mallan.yujeongran.icebreaking.question_game.service.QuestionGameService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/question/game")
+@RequiredArgsConstructor
+@Tag(name = "Question Game API", description = "오픈 퀘스천 게임 진행 관련 API")
+public class QuestionGameController {
+
+    private final QuestionGameService questionGameService;
+
+    @PostMapping("/{roomCode}/start")
+    @Operation(summary = "게임 시작 API", description = "주제 ID와 문제 수에 따라 게임을 시작합니다.")
+    public ResponseEntity<CommonResponse<Void>> startGame(
+            @PathVariable String roomCode,
+            @RequestParam int topicId,
+            @RequestParam int questionCount
+    ) {
+        questionGameService.startGame(roomCode, topicId, questionCount);
+        return ResponseEntity.ok(CommonResponse.success("게임 시작 완료!", null));
+    }
+
+    @GetMapping("/{roomCode}/draw")
+    @Operation(summary = "질문 뽑기 API", description = "랜덤 질문을 하나 뽑습니다.")
+    public ResponseEntity<CommonResponse<QuestionDrawResponseDto>> drawQuestion(
+            @PathVariable String roomCode
+    ) {
+        QuestionDrawResponseDto question = questionGameService.drawQuestion(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("질문 뽑기 완료", question));
+    }
+
+    @GetMapping("/{roomCode}/players/selectable")
+    @Operation(summary = "답변자 선택 가능한 플레이어 리스트 API", description = "질문자를 제외한 플레이어 목록을 반환합니다.")
+    public ResponseEntity<CommonResponse<QuestionSelectablePlayerListResponseDto>> getSelectablePlayers(
+            @PathVariable String roomCode,
+            @RequestParam String questionerId
+    ) {
+        QuestionSelectablePlayerListResponseDto response = questionGameService.getSelectablePlayers(roomCode, questionerId);
+        return ResponseEntity.ok(CommonResponse.success("선택 가능한 플레이어 조회 성공", response));
+    }
+
+    @PostMapping("/{roomCode}/select")
+    @Operation(summary = "답변자 지정 API", description = "질문자가 답변자를 선택합니다.")
+    public ResponseEntity<CommonResponse<Void>> selectAnswerer(
+            @PathVariable String roomCode,
+            @RequestBody QuestionSelectAnswererRequestDto request
+    ) {
+        questionGameService.selectAnswerer(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("답변자 선택 완료", null));
+    }
+
+    @PostMapping("/{roomCode}/answer")
+    @Operation(summary = "답변 제출 API", description = "지목된 사용자가 질문에 답변을 완료합니다.")
+    public ResponseEntity<CommonResponse<Void>> submitAnswer(
+            @PathVariable String roomCode,
+            @RequestBody QuestionSubmitAnswerRequestDto request
+    ) {
+        questionGameService.submitAnswer(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("답변 완료", null));
+    }
+
+    @GetMapping("/{roomCode}/finished")
+    @Operation(summary = "게임 종료 여부 확인 API", description = "남은 질문이 있는지 확인합니다.")
+    public ResponseEntity<CommonResponse<Boolean>> isGameFinished(
+            @PathVariable String roomCode
+    ) {
+        boolean result = questionGameService.isGameFinished(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("게임 종료 여부 확인", result));
+    }
+
+    @PostMapping("/{roomCode}/restart")
+    @Operation(summary = "게임 재시작 API", description = "기존 게임 데이터를 초기화하고 새 게임을 시작합니다.")
+    public ResponseEntity<CommonResponse<Void>> restartGame(
+            @PathVariable String roomCode,
+            @RequestParam int topicId,
+            @RequestParam int questionCount,
+            @RequestBody QuestionRestartGameRequestDto request
+    ) {
+        questionGameService.restartGame(roomCode, request, topicId, questionCount);
+        return ResponseEntity.ok(CommonResponse.success("게임 재시작 완료!", null));
+    }
+
+    @DeleteMapping("/{roomCode}/end")
+    @Operation(summary = "게임 종료 API", description = "게임을 완전히 종료하고 모든 관련 데이터를 삭제합니다.")
+    public ResponseEntity<CommonResponse<Void>> endGame(
+            @PathVariable String roomCode,
+            @RequestBody QuestionEndGameRequestDto request
+    ) {
+        questionGameService.endGame(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("게임 종료 완료", null));
+    }
+
+    @GetMapping("/{roomCode}/current")
+    @Operation(summary = "현재 질문 상태 조회 API", description = "현재 질문자, 답변자, 질문 내용을 조회합니다.")
+    public ResponseEntity<CommonResponse<QuestionCurrentQuestionStateResponseDto>> getCurrentQuestionState(
+            @PathVariable String roomCode
+    ) {
+        QuestionCurrentQuestionStateResponseDto response = questionGameService.getCurrentQuestionState(roomCode);
+        return ResponseEntity.ok(CommonResponse.success("현재 질문 상태 조회 성공", response));
+    }
+
+    @GetMapping("/{roomCode}/role")
+    @Operation(summary = "플레이어 역할 조회 API", description = "플레이어가 질문자인지 답변자인지 확인합니다.")
+    public ResponseEntity<CommonResponse<QuestionPlayerRoleResponseDto>> getPlayerRole(
+            @PathVariable String roomCode,
+            @RequestParam String playerId
+    ) {
+        QuestionPlayerRoleResponseDto response = questionGameService.getPlayerRole(roomCode, playerId);
+        return ResponseEntity.ok(CommonResponse.success("플레이어 역할 조회 성공", response));
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/controller/QuestionRoomController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/controller/QuestionRoomController.java
@@ -1,0 +1,83 @@
+package com.mallan.yujeongran.icebreaking.question_game.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.*;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.*;
+import com.mallan.yujeongran.icebreaking.question_game.service.QuestionRoomService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/question/room")
+@RequiredArgsConstructor
+@Tag(name = "Question Room API", description = "오픈 퀘스천 게임 방 관련 API")
+public class QuestionRoomController {
+
+    private final QuestionRoomService questionRoomService;
+
+    @PostMapping
+    @Operation(summary = "방 생성 API", description = "닉네임과 프로필 이미지를 입력받아 방을 생성합니다.")
+    public ResponseEntity<CommonResponse<QuestionCreateRoomResponseDto>> createRoom(
+            @RequestBody QuestionCreateRoomRequestDto request
+    ) {
+        QuestionCreateRoomResponseDto response = questionRoomService.createRoom(request);
+        return ResponseEntity.ok(CommonResponse.success("방 생성 성공!", response));
+    }
+
+    @PostMapping("/{roomCode}/join")
+    @Operation(summary = "방 입장 API", description = "닉네임과 프로필 이미지를 입력받아 방에 입장합니다.")
+    public ResponseEntity<CommonResponse<QuestionJoinRoomResponseDto>> joinRoom(
+            @PathVariable String roomCode,
+            @RequestBody QuestionJoinRoomRequestDto request
+    ) {
+        QuestionJoinRoomResponseDto response = questionRoomService.joinRoom(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("방 입장 성공!", response));
+    }
+
+    @PostMapping("/{roomCode}/exit")
+    @Operation(summary = "방 퇴장 API", description = "플레이어가 방을 나가며 방 인원이 0명이면 삭제됩니다.")
+    public ResponseEntity<CommonResponse<QuestionExitRoomResponseDto>> exitRoom(
+            @PathVariable String roomCode,
+            @RequestBody QuestionExitRoomRequestDto request
+    ) {
+        QuestionExitRoomResponseDto responseDto = questionRoomService.exitRoom(roomCode, request.getPlayerId());
+        return ResponseEntity.ok(CommonResponse.success("방 나가기 완료", responseDto));
+    }
+
+    @PostMapping("/{roomCode}/set-question-count")
+    @Operation(summary = "문제 수 설정 API", description = "방장이 문제 수를 설정합니다.")
+    public ResponseEntity<CommonResponse<QuestionSetQuestionCountResponseDto>> setQuestionCount(
+            @PathVariable String roomCode,
+            @RequestBody QuestionSetQuestionCountRequestDto request
+    ) {
+        return ResponseEntity.ok(
+                CommonResponse.success("문제 수 설정 성공", questionRoomService.setQuestionCount(roomCode, request))
+        );
+    }
+
+    @PostMapping("/{roomCode}/set-topic")
+    @Operation(summary = "주제 설정 API", description = "방장이 주제를 설정합니다.")
+    public ResponseEntity<CommonResponse<QuestionSetTopicResponseDto>> setTopic(
+            @PathVariable String roomCode,
+            @RequestBody QuestionSetTopicRequestDto request
+    ) {
+        return ResponseEntity.ok(
+                CommonResponse.success("주제 설정 성공", questionRoomService.setTopic(roomCode, request))
+        );
+    }
+
+    @PostMapping("/{roomCode}/start")
+    @Operation(summary = "게임 시작 API", description = "방장이 게임을 시작합니다.")
+    public ResponseEntity<CommonResponse<Void>> startGame(
+            @PathVariable String roomCode,
+            @RequestBody QuestionGameStartRequestDto request
+    ) {
+        questionRoomService.startGame(roomCode, request);
+        return ResponseEntity.ok(CommonResponse.success("게임 시작 성공", null));
+    }
+
+}
+

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionCreateRoomRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionCreateRoomRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionCreateRoomRequestDto {
+
+    @Schema(description = "닉네임", example = "Noah")
+    private String Nickname;
+
+    @Schema(description = "프로필 이미지", example = "avatar_1_140x140.png")
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionEndGameRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionEndGameRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionEndGameRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "l1m24ij5")
+    private String playerId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionExitRoomRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionExitRoomRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionExitRoomRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "kl2m41k2")
+    private String playerId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionGameStartRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionGameStartRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionGameStartRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "34lk5m10")
+    private String playerId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionJoinRoomRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionJoinRoomRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionJoinRoomRequestDto {
+
+    @Schema(description = "닉네임", example = "Noah")
+    private String nickname;
+
+    @Schema(description = "프로필 이미지", example = "avatar_1_140x140.png")
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionRestartGameRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionRestartGameRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionRestartGameRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "l1m24ij5")
+    private String playerId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSelectAnswererRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSelectAnswererRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionSelectAnswererRequestDto {
+
+    @Schema(description = "질문자 아이디", example = "46lm12kj")
+    private String questionerId;
+
+    @Schema(description = "답변자 아이디", example = "67lk291p")
+    private String answererId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSetQuestionCountRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSetQuestionCountRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionSetQuestionCountRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "01ml37l1")
+    private String playerId;
+
+    @Schema(description = "문제 수", example = "6")
+    private int questionCount;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSetTopicRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSetTopicRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionSetTopicRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "lm3512bh")
+    private String playerId;
+
+    @Schema(description = "주제 아이디", example = "3")
+    private int topicId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSubmitAnswerRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/request/QuestionSubmitAnswerRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class QuestionSubmitAnswerRequestDto {
+
+    @Schema(description = "플레이어 아이디", example = "1l2m54kj")
+    private String playerId;
+
+    @Schema(description = "질문 아아디", example = "1")
+    private Long questionId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionCreateRoomResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionCreateRoomResponseDto.java
@@ -1,0 +1,16 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionCreateRoomResponseDto {
+
+    private String roomCode;
+    private String hostId;
+    private String hostNickname;
+    private String hostProfileImage;
+    private String url;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionCurrentQuestionStateResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionCurrentQuestionStateResponseDto.java
@@ -1,0 +1,17 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionCurrentQuestionStateResponseDto {
+
+    private String questionerId;
+    private String questionerNickname;
+    private Long questionId;
+    private String questionContent;
+    private String answererId;
+    private String answererNickname;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionDrawResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionDrawResponseDto.java
@@ -1,0 +1,13 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class QuestionDrawResponseDto {
+
+    private Long questionId;
+    private String questionContent;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionExitRoomResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionExitRoomResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionExitRoomResponseDto {
+
+    private String roomCode;
+    private String playerId;
+    private String nickname;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionJoinRoomResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionJoinRoomResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionJoinRoomResponseDto {
+
+    private String nickname;
+    private String playerId;
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionPlayerRoleResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionPlayerRoleResponseDto.java
@@ -1,0 +1,17 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionPlayerRoleResponseDto {
+
+    /*
+    * "questioner", "answerer", "none"
+    * 으로 구분해서 현재 플레이어가 어떤 상태의 역할인지 확인하려고 함.
+    * 역할을 Enum클래스로 넘겨서 받아야하나 고민
+    * */
+    private String role;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSelectablePlayerListResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSelectablePlayerListResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class QuestionSelectablePlayerListResponseDto {
+
+    private List<QuestionSelectablePlayerResponseDto> players;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSelectablePlayerResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSelectablePlayerResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionSelectablePlayerResponseDto {
+
+    private String playerId;
+    private String nickname;
+    private String profileImage;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSetQuestionCountResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSetQuestionCountResponseDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionSetQuestionCountResponseDto {
+
+    private int questionCount;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSetTopicResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/dto/response/QuestionSetTopicResponseDto.java
@@ -1,0 +1,13 @@
+package com.mallan.yujeongran.icebreaking.question_game.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class QuestionSetTopicResponseDto {
+
+    private int topicId;
+    private String topic;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionHistory.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionHistory.java
@@ -1,0 +1,47 @@
+package com.mallan.yujeongran.icebreaking.question_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "open_question_history")
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class QuestionHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_code", nullable = false)
+    private String roomCode;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "topic_id", nullable = false)
+    private QuestionTopic topic;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
+    private QuestionQuestion question;
+
+    @Column(nullable = false)
+    private String questionerPlayerId;
+
+    @Column(nullable = false)
+    private String answererPlayerId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}
+

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionPlayer.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionPlayer.java
@@ -1,0 +1,40 @@
+package com.mallan.yujeongran.icebreaking.question_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "question_player")
+@Builder
+public class QuestionPlayer {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_code", nullable = false)
+    private String roomCode;
+
+    @Column(name = "nickname", nullable = false)
+    private String nickname;
+
+    @Column(name = "player_id", nullable = false)
+    private String playerId;
+
+    @Column(name = "profile_image", nullable = false)
+    private String profileImage;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionQuestion.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionQuestion.java
@@ -1,0 +1,34 @@
+package com.mallan.yujeongran.icebreaking.question_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "question_question")
+@Builder
+public class QuestionQuestion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "topic_id", nullable = false)
+    private QuestionTopic topic;
+
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionRoom.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionRoom.java
@@ -1,0 +1,49 @@
+package com.mallan.yujeongran.icebreaking.question_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "question_room")
+@Builder
+public class QuestionRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "room_code", nullable = false)
+    private String roomCode;
+
+    @Column(name = "host_id", nullable = false)
+    private String hostId;
+
+    @Column(name = "host_nickname", nullable = false)
+    private String hostNickname;
+
+    @Column(name = "url", nullable = false)
+    private String url;
+
+    @Column(name = "player_count", nullable = false)
+    private int playerCount;
+
+    @Column(name = "question_count", nullable = false)
+    private int questionCount;
+
+    @Column(name = "topic_id", nullable = false)
+    private int topicId;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionTopic.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/entity/QuestionTopic.java
@@ -1,0 +1,30 @@
+package com.mallan.yujeongran.icebreaking.question_game.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "question_player")
+@Builder
+public class QuestionTopic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "topic", nullable = false)
+    private String topic;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionPlayerRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionPlayerRepository.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.repository;
+
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionPlayer;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestionPlayerRepository extends JpaRepository<QuestionPlayer, Long> {
+
+    List<QuestionPlayer> findByRoomCode(String roomCode);
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionQuestionRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionQuestionRepository.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.question_game.repository;
+
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface QuestionQuestionRepository extends JpaRepository<QuestionQuestion, Long> {
+
+    List<QuestionQuestion> findByTopicId(int topicId);
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionRoomRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionRoomRepository.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.question_game.repository;
+
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+public interface QuestionRoomRepository extends JpaRepository<QuestionRoom, Long> {
+
+    Optional<QuestionRoom> findByRoomCode(String roomCode);
+    List<QuestionRoom> findByCreatedAtBefore(LocalDateTime time);
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionTopicRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/repository/QuestionTopicRepository.java
@@ -1,0 +1,10 @@
+package com.mallan.yujeongran.icebreaking.question_game.repository;
+
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionTopic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuestionTopicRepository extends JpaRepository<QuestionTopic, Long> {
+
+
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/scheduler/QuestionRoomCleanupScheduler.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/scheduler/QuestionRoomCleanupScheduler.java
@@ -1,0 +1,47 @@
+package com.mallan.yujeongran.icebreaking.question_game.scheduler;
+
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionRoom;
+import com.mallan.yujeongran.icebreaking.question_game.repository.QuestionRoomRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+public class QuestionRoomCleanupScheduler {
+
+    private final QuestionRoomRepository questionRoomRepository;
+    private final RedisTemplate<String, String> redisTemplate;
+
+    @Scheduled(fixedRate = 60 * 60 * 1000)
+    public void deleteExpiredRooms() {
+        LocalDateTime now = LocalDateTime.now().minusHours(24);
+        List<QuestionRoom> expiredRooms = questionRoomRepository.findByCreatedAtBefore(now);
+
+        for (QuestionRoom room : expiredRooms) {
+            String roomCode = room.getRoomCode();
+
+            redisTemplate.delete("question:room:" + roomCode);
+            redisTemplate.delete("question:room:" + roomCode + ":players");
+            redisTemplate.delete("question:room:" + roomCode + ":questions");
+            redisTemplate.delete("question:room:" + roomCode + ":currentQuestionId");
+            redisTemplate.delete("question:room:" + roomCode + ":questionerId");
+            redisTemplate.delete("question:room:" + roomCode + ":answererId");
+            redisTemplate.delete("question:room:" + roomCode + ":nextQuestionerId");
+
+            List<String> playerIds = redisTemplate.opsForList().range("question:room:" + roomCode + ":players", 0, -1);
+            if (playerIds != null) {
+                for (String playerId : playerIds) {
+                    redisTemplate.delete("question:player:" + playerId + ":nickname");
+                    redisTemplate.delete("question:player:" + playerId + ":profileImage");
+                }
+            }
+
+            questionRoomRepository.delete(room);
+        }
+    }
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/service/QuestionGameService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/service/QuestionGameService.java
@@ -1,0 +1,186 @@
+package com.mallan.yujeongran.icebreaking.question_game.service;
+
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionEndGameRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionRestartGameRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionSelectAnswererRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.QuestionSubmitAnswerRequestDto;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.*;
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionQuestion;
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionTopic;
+import com.mallan.yujeongran.icebreaking.question_game.repository.QuestionQuestionRepository;
+import com.mallan.yujeongran.icebreaking.question_game.repository.QuestionRoomRepository;
+import com.mallan.yujeongran.icebreaking.question_game.repository.QuestionTopicRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuestionGameService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final QuestionTopicRepository questiontopicRepository;
+    private final QuestionQuestionRepository questionquestionRepository;
+    private final QuestionRoomRepository questionRoomRepository;
+
+    public void startGame(String roomCode, int topicId, int questionCount) {
+        QuestionTopic topic = questiontopicRepository.findById((long) topicId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 주제를 찾을 수 없습니다."));
+
+        List<QuestionQuestion> questions = questionquestionRepository.findByTopicId(topicId);
+        Collections.shuffle(questions);
+
+        int count = Math.min(questionCount, questions.size());
+        for (int i = 0; i < count; i++) {
+            redisTemplate.opsForList().rightPush("question:room:" + roomCode + ":questions", String.valueOf(questions.get(i).getId()));
+        }
+    }
+
+    public QuestionDrawResponseDto drawQuestion(String roomCode) {
+        String questionId = redisTemplate.opsForList().leftPop("question:room:" + roomCode + ":questions");
+        if (questionId == null) {
+            throw new IllegalStateException("더 이상 남은 질문이 없습니다.");
+        }
+
+        redisTemplate.opsForValue().set("question:room:" + roomCode + ":currentQuestionId", questionId);
+
+        QuestionQuestion question = questionquestionRepository.findById(Long.parseLong(questionId))
+                .orElseThrow(() -> new IllegalArgumentException("해당 질문을 찾을 수 없습니다."));
+
+        return QuestionDrawResponseDto.builder()
+                .questionId(question.getId())
+                .questionContent(question.getContent())
+                .build();
+    }
+
+    public void selectAnswerer(String roomCode, QuestionSelectAnswererRequestDto request) {
+        redisTemplate.opsForValue().set("question:room:" + roomCode + ":questionerId", request.getQuestionerId());
+        redisTemplate.opsForValue().set("question:room:" + roomCode + ":answererId", request.getAnswererId());
+    }
+
+    public void submitAnswer(String roomCode, QuestionSubmitAnswerRequestDto request) {
+        String currentAnswerer = redisTemplate.opsForValue().get("question:room:" + roomCode + ":answererId");
+
+        if (!request.getPlayerId().equals(currentAnswerer)) {
+            throw new IllegalArgumentException("해당 플레이어는 답변자가 아닙니다.");
+        }
+
+        redisTemplate.opsForValue().set("question:room:" + roomCode + ":nextQuestionerId", currentAnswerer);
+
+        redisTemplate.delete("question:room:" + roomCode + ":answererId");
+        redisTemplate.delete("question:room:" + roomCode + ":questionerId");
+        redisTemplate.delete("question:room:" + roomCode + ":currentQuestionId");
+    }
+
+    public void cleanupGameData(String roomCode) {
+        redisTemplate.delete("question:room:" + roomCode + ":questions");
+        redisTemplate.delete("question:room:" + roomCode + ":currentQuestionId");
+        redisTemplate.delete("question:room:" + roomCode + ":questionerId");
+        redisTemplate.delete("question:room:" + roomCode + ":answererId");
+        redisTemplate.delete("question:room:" + roomCode + ":nextQuestionerId");
+    }
+
+    public boolean isGameFinished(String roomCode) {
+        Long remaining = redisTemplate.opsForList().size("question:room:" + roomCode + ":questions");
+        return remaining == null || remaining == 0;
+    }
+
+    public void restartGame(String roomCode, QuestionRestartGameRequestDto request, int topicId, int questionCount) {
+        String hostId = (String) redisTemplate.opsForHash().get("question:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 게임을 재시작할 수 있습니다.");
+        }
+
+        cleanupGameData(roomCode);
+        startGame(roomCode, topicId, questionCount);
+    }
+
+    public void endGame(String roomCode, QuestionEndGameRequestDto request) {
+        String hostId = (String) redisTemplate.opsForHash().get("question:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 게임을 종료할 수 있습니다.");
+        }
+
+        cleanupGameData(roomCode);
+        redisTemplate.delete("question:room:" + roomCode);
+        redisTemplate.delete("question:room:" + roomCode + ":players");
+
+        List<String> playerIds = redisTemplate.opsForList().range("question:room:" + roomCode + ":players", 0, -1);
+        if (playerIds != null) {
+            for (String playerId : playerIds) {
+                redisTemplate.delete("question:player:" + playerId + ":nickname");
+                redisTemplate.delete("question:player:" + playerId + ":profileImage");
+            }
+        }
+
+        questionRoomRepository.findByRoomCode(roomCode)
+                .ifPresent(questionRoomRepository::delete);
+    }
+
+    public QuestionSelectablePlayerListResponseDto getSelectablePlayers(String roomCode, String questionerId) {
+        List<String> allPlayers = redisTemplate.opsForList().range("question:room:" + roomCode + ":players", 0, -1);
+
+        if (allPlayers == null) {
+            throw new IllegalArgumentException("플레이어 목록을 불러올 수 없습니다.");
+        }
+
+        List<QuestionSelectablePlayerResponseDto> filtered = allPlayers.stream()
+                .filter(id -> !id.equals(questionerId))
+                .map(id -> QuestionSelectablePlayerResponseDto.builder()
+                        .playerId(id)
+                        .nickname(redisTemplate.opsForValue().get("question:player:" + id + ":nickname"))
+                        .profileImage(redisTemplate.opsForValue().get("question:player:" + id + ":profileImage"))
+                        .build())
+                .toList();
+
+        return QuestionSelectablePlayerListResponseDto.builder()
+                .players(filtered)
+                .build();
+    }
+
+    public QuestionCurrentQuestionStateResponseDto getCurrentQuestionState(String roomCode) {
+        String questionerId = redisTemplate.opsForValue().get("question:room:" + roomCode + ":questionerId");
+        String answererId = redisTemplate.opsForValue().get("question:room:" + roomCode + ":answererId");
+        String questionId = redisTemplate.opsForValue().get("question:room:" + roomCode + ":currentQuestionId");
+
+        if (questionerId == null || answererId == null || questionId == null) {
+            throw new IllegalStateException("진행 중인 질문 정보가 없습니다.");
+        }
+
+        String questionerNickname = redisTemplate.opsForValue().get("question:player:" + questionerId + ":nickname");
+        String answererNickname = redisTemplate.opsForValue().get("question:player:" + answererId + ":nickname");
+
+        QuestionQuestion question = questionquestionRepository.findById(Long.parseLong(questionId))
+                .orElseThrow(() -> new IllegalArgumentException("질문을 찾을 수 없습니다."));
+
+        return QuestionCurrentQuestionStateResponseDto.builder()
+                .questionerId(questionerId)
+                .questionerNickname(questionerNickname)
+                .questionId(question.getId())
+                .questionContent(question.getContent())
+                .answererId(answererId)
+                .answererNickname(answererNickname)
+                .build();
+    }
+
+    public QuestionPlayerRoleResponseDto getPlayerRole(String roomCode, String playerId) {
+        String questionerId = redisTemplate.opsForValue().get("question:room:" + roomCode + ":questionerId");
+        String answererId = redisTemplate.opsForValue().get("question:room:" + roomCode + ":answererId");
+
+        if (playerId.equals(questionerId)) {
+            return QuestionPlayerRoleResponseDto.builder().role("questioner").build();
+        } else if (playerId.equals(answererId)) {
+            return QuestionPlayerRoleResponseDto.builder().role("answerer").build();
+        } else {
+            return QuestionPlayerRoleResponseDto.builder().role("none").build();
+        }
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/service/QuestionRoomService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/question_game/service/QuestionRoomService.java
@@ -1,0 +1,168 @@
+package com.mallan.yujeongran.icebreaking.question_game.service;
+
+import com.mallan.yujeongran.icebreaking.question_game.dto.request.*;
+import com.mallan.yujeongran.icebreaking.question_game.dto.response.*;
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionRoom;
+import com.mallan.yujeongran.icebreaking.question_game.entity.QuestionTopic;
+import com.mallan.yujeongran.icebreaking.question_game.repository.QuestionRoomRepository;
+import com.mallan.yujeongran.icebreaking.question_game.repository.QuestionTopicRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuestionRoomService {
+
+    private final RedisTemplate<String, String> redisTemplate;
+    private final QuestionRoomRepository questionRoomRepository;
+    private final QuestionTopicRepository questionTopicRepository;
+
+    @Value("${QUESTION_ROOM_BASE_URL}")
+    private String baseUrl;
+
+    public QuestionCreateRoomResponseDto createRoom(QuestionCreateRoomRequestDto request) {
+        String playerId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String roomCode = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String nickname = request.getNickname();
+        String profileImage = request.getProfileImage();
+
+        redisTemplate.opsForValue().set("question:player:" + playerId + ":nickname", nickname);
+        redisTemplate.opsForValue().set("question:player:" + playerId + ":profileImage", profileImage);
+        redisTemplate.opsForList().rightPush("question:room:" + roomCode + ":players", playerId);
+        redisTemplate.opsForHash().put("question:room:" + roomCode, "hostId", playerId);
+
+        redisTemplate.expire("question:room:" + roomCode, Duration.ofHours(24));
+        redisTemplate.expire("question:room:" + roomCode + ":players", Duration.ofHours(24));
+
+        QuestionRoom room = QuestionRoom.builder()
+                .roomCode(roomCode)
+                .hostId(playerId)
+                .hostNickname(nickname)
+                .questionCount(0)
+                .topicId(0)
+                .playerCount(1)
+                .url(baseUrl + "/question/" + roomCode)
+                .build();
+        questionRoomRepository.save(room);
+
+        return QuestionCreateRoomResponseDto.builder()
+                .roomCode(roomCode)
+                .hostId(playerId)
+                .hostNickname(nickname)
+                .hostProfileImage(profileImage)
+                .url(room.getUrl())
+                .build();
+    }
+
+    public QuestionJoinRoomResponseDto joinRoom(String roomCode, QuestionJoinRoomRequestDto request) {
+        Boolean exists = redisTemplate.hasKey("question:room:" + roomCode);
+        if (exists == null || !exists) {
+            throw new IllegalArgumentException("해당 방이 존재하지 않습니다.");
+        }
+
+        String playerId = UUID.randomUUID().toString().replace("-", "").substring(0, 8);
+        String nickname = request.getNickname();
+        String profileImage = request.getProfileImage();
+
+        redisTemplate.opsForValue().set("question:player:" + playerId + ":nickname", nickname);
+        redisTemplate.opsForValue().set("question:player:" + playerId + ":profileImage", profileImage);
+        redisTemplate.opsForList().rightPush("question:room:" + roomCode + ":players", playerId);
+
+        questionRoomRepository.findByRoomCode(roomCode).ifPresent(room -> {
+            room.setPlayerCount(room.getPlayerCount() + 1);
+            questionRoomRepository.save(room);
+        });
+
+        return QuestionJoinRoomResponseDto.builder()
+                .playerId(playerId)
+                .nickname(nickname)
+                .profileImage(profileImage)
+                .build();
+    }
+
+    public QuestionExitRoomResponseDto exitRoom(String roomCode, String playerId) {
+        String nickname = redisTemplate.opsForValue().get("question:player:" + playerId + ":nickname");
+
+        redisTemplate.opsForList().remove("question:room:" + roomCode + ":players", 1, playerId);
+        redisTemplate.delete("question:player:" + playerId + ":nickname");
+        redisTemplate.delete("question:player:" + playerId + ":profileImage");
+
+        questionRoomRepository.findByRoomCode(roomCode).ifPresent(room -> {
+            int current = room.getPlayerCount();
+            room.setPlayerCount(Math.max(0, current - 1));
+            questionRoomRepository.save(room);
+
+            if (room.getPlayerCount() == 0) {
+                redisTemplate.delete("question:room:" + roomCode);
+                redisTemplate.delete("question:room:" + roomCode + ":players");
+
+                questionRoomRepository.delete(room);
+            }
+        });
+
+        return QuestionExitRoomResponseDto.builder()
+                .roomCode(roomCode)
+                .playerId(playerId)
+                .nickname(nickname)
+                .build();
+    }
+
+    public QuestionSetQuestionCountResponseDto setQuestionCount(String roomCode, QuestionSetQuestionCountRequestDto request) {
+        String hostId = (String) redisTemplate.opsForHash().get("question:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 문제 수를 설정할 수 있습니다.");
+        }
+
+        QuestionRoom room = questionRoomRepository.findByRoomCode(roomCode)
+                .orElseThrow(() -> new IllegalArgumentException("해당 방이 존재하지 않습니다."));
+
+        room.setQuestionCount(request.getQuestionCount());
+        questionRoomRepository.save(room);
+
+        return QuestionSetQuestionCountResponseDto.builder()
+                .questionCount(request.getQuestionCount())
+                .build();
+    }
+
+    public QuestionSetTopicResponseDto setTopic(String roomCode, QuestionSetTopicRequestDto request) {
+        String hostId = (String) redisTemplate.opsForHash().get("question:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 주제를 설정할 수 있습니다.");
+        }
+
+        QuestionRoom room = questionRoomRepository.findByRoomCode(roomCode)
+                .orElseThrow(() -> new IllegalArgumentException("해당 방이 존재하지 않습니다."));
+
+        room.setTopicId(request.getTopicId());
+        questionRoomRepository.save(room);
+
+        QuestionTopic topic = questionTopicRepository.findById((long) request.getTopicId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 주제가 존재하지 않습니다."));
+
+        return QuestionSetTopicResponseDto.builder()
+                .topicId(topic.getId().intValue())
+                .topic(topic.getTopic())
+                .build();
+    }
+
+    public void startGame(String roomCode, QuestionGameStartRequestDto request) {
+        String hostId = (String) redisTemplate.opsForHash().get("question:room:" + roomCode, "hostId");
+
+        if (!request.getPlayerId().equals(hostId)) {
+            throw new IllegalArgumentException("방장만 게임을 시작할 수 있습니다.");
+        }
+
+        redisTemplate.opsForValue().set("question:room:" + roomCode + ":started", "true", Duration.ofHours(24));
+    }
+
+
+}


### PR DESCRIPTION
## 📋 Summary

> - closes #25 
**오픈 퀘스천 게임괴 괸련한 기능을 구현합니다.**

## ✅ Tasks

- 닉네임과 프로필 이미지를 입력 후 방 생성 및 입장 기능
- 닉네임과 프로필 이미지를 입력 후 방 입장 기능
- 호스트 사용자의 문제 수 설정 기능
- 호스트 사용자의 주제 설정 기능
- 호스트 사용자의 게임 시작 기능
- 제출자 플레이어의 문제 뽑기 기능
- 제출자 플레이어의 답변자 선정 기능
- 답변자 플레이어의 답변 후 답변 완료 기능
- 답변자 플레이어긔 답변 완료 이후 제출자 플레이어로 전환 기능
- 모든 문제 이후 문제 소진 검증 기능
- 문제 소진 이후 게임 다시하기 혹은 종료 기능

## ✏️ To Reviewer

- 모든 기능을 구현하고 Swagger테스트 이후 PR을 올렸으나 미비한 부분이 있어서 디테일한 기능들은 수정하고 개선할 예정입니다.
- 최대한 버튼 하나에 하나의 API만 동작하게 설계하고 개선합니다.
- 부족한 부분을 계속 확인 중에 있습니다.

## 📷 Screenshot

<img width="1099" alt="스크린샷 2025-05-26 오후 11 51 47" src="https://github.com/user-attachments/assets/4fbbd4b5-3d30-4c70-a584-b26afde8036f" />

