### PR TITLE
[#53] 관리자 계정 관련 기능 구현

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -18,22 +18,24 @@ repositories {
 }
 
 dependencies {
-    // Spring Boot Setting
+    // Spring Web
     implementation 'org.springframework.boot:spring-boot-starter-web'
+
+    // Spring Web Services (SOAP 지원용)
     implementation 'org.springframework.boot:spring-boot-starter-web-services'
 
-    // Jpa
+    // Spring Data Jpa
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
-    // Security
+    // Security Security
     implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // Spring Mustache
+    implementation 'org.springframework.boot:spring-boot-starter-mustache'
 
     // Lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
-
-    // MySQL
-    // runtimeOnly 'com.mysql:mysql-connector-j'
 
     // PostgreSQL
     runtimeOnly 'org.postgresql:postgresql'
@@ -55,14 +57,14 @@ dependencies {
     // Bean Validation Provider
     implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
     implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
-
-    // Jakarta Validation
-    implementation 'org.hibernate.validator:hibernate-validator:8.0.1.Final'
-    implementation 'jakarta.validation:jakarta.validation-api:3.0.2'
     implementation 'org.glassfish:jakarta.el:4.0.2'
 
     // dotenv-java
     implementation 'io.github.cdimascio:dotenv-java:2.2.0'
+
+    // BCrypt Password Encoder
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
 
 }
 

--- a/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
@@ -40,7 +40,8 @@ public class SecurityConfig {
                                 "/liar/**",
                                 "/balance/**",
                                 "/coin/**",
-                                "/question/**"
+                                "/question/**",
+                                "/reviews/**"
                         ).permitAll()
                         // 그 외에는 인증 필요
                         .anyRequest().authenticated()

--- a/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
@@ -2,10 +2,10 @@ package com.mallan.yujeongran.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.Customizer;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
 import java.util.List;
@@ -13,6 +13,11 @@ import java.util.List;
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
+
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -36,19 +41,22 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html"
                         ).permitAll()
+
+                        // 게임 관련 API Path 허용
                         .requestMatchers(
                                 "/liar/**",
                                 "/balance/**",
                                 "/coin/**",
                                 "/question/**",
-                                "/reviews/**"
+                                "/reviews/**",
+                                "/admin/**"
                         ).permitAll()
+
                         // 그 외에는 인증 필요
                         .anyRequest().authenticated()
-
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
-                .httpBasic(Customizer.withDefaults());
+                .httpBasic(AbstractHttpConfigurer::disable);
 
         return http.build();
     }

--- a/backend/src/main/java/com/mallan/yujeongran/config/SwaggerConfig.java
+++ b/backend/src/main/java/com/mallan/yujeongran/config/SwaggerConfig.java
@@ -3,6 +3,9 @@ package com.mallan.yujeongran.config;
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityScheme.In;
+import io.swagger.v3.oas.models.security.SecurityScheme.Type;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -12,7 +15,14 @@ public class SwaggerConfig {
     @Bean
     public OpenAPI openAPI() {
         return new OpenAPI()
-                .components(new Components())
+                .components(new Components()
+                        .addSecuritySchemes("Authorization",
+                                new SecurityScheme()
+                                        .type(Type.APIKEY)
+                                        .in(In.HEADER)
+                                        .name("Authorization")
+                        )
+                )
                 .info(apiInfo());
     }
 
@@ -22,27 +32,27 @@ public class SwaggerConfig {
                 .version("1.0.0")
                 .description(
                         """
-                        ## 🧊 아이스브레이킹 API 명세서
-                        ---
-                        ### 📍팀명
-                        🥚Mallan
-                        ### 🐣팀원
-                        🙋🏻‍♀️유지수(프론트엔드)
-                        \n\n
-                        🙋🏻‍♂️이정훈(백엔드)
-                        \n\n
-                        ### 🎮게임 항목
-                        - 밸런스게임
-                        - 라이어게임
-                        - 랜덤 퀘스천 뽑기게임
-                        - 공통점 찾기 게임
-                        - 동전 진실게임 
-                        ### 🔗 링크
-                        📌 [Mallan-Web] 등록 예정 
-                        📌 [GitHub](https://github.com/yujeong-ran/mallan) 
-                        📌 [Notion](https://www.notion.so/1eca7efc6b0380ee8f99f5d528ef8200)
-                        📌 [Jira](https://qweqwerty12321-1740141206278.atlassian.net/jira/software/projects/MAL/pages)
-                        """
+                                ## 🧊 아이스브레이킹 API 명세서
+                                ---
+                                ### 📍팀명
+                                🥚Mallan
+                                ### 🐣팀원
+                                🙋🏻‍♀️유지수(프론트엔드)
+                                \n\n
+                                🙋🏻‍♂️이정훈(백엔드)
+                                \n\n
+                                ### 🎮게임 항목
+                                - 밸런스게임
+                                - 라이어게임
+                                - 랜덤 퀘스천 뽑기게임
+                                - 공통점 찾기 게임
+                                - 동전 진실게임 
+                                ### 🔗 링크
+                                📌 [Mallan-Web] 등록 예정 
+                                📌 [GitHub](https://github.com/yujeong-ran/mallan) 
+                                📌 [Notion](https://www.notion.so/1eca7efc6b0380ee8f99f5d528ef8200)
+                                📌 [Jira](https://qweqwerty12321-1740141206278.atlassian.net/jira/software/projects/MAL/pages)
+                                """
                 );
     }
 

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/controller/AdminController.java
@@ -1,0 +1,52 @@
+package com.mallan.yujeongran.icebreaking.admin.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.admin.dto.request.CreateLoginIdRequestDto;
+import com.mallan.yujeongran.icebreaking.admin.dto.request.DeleteLoginIdRequestDto;
+import com.mallan.yujeongran.icebreaking.admin.dto.response.CreateLoginIdResponseDto;
+import com.mallan.yujeongran.icebreaking.admin.service.AdminService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/admin")
+@RequiredArgsConstructor
+@Tag(name = "Admin API", description = "관리자 계정 관련 API")
+public class AdminController {
+
+    private final AdminService adminService;
+
+    @Value("${ADMIN_SECRET_KEY}")
+    private String adminSecretKey;
+
+    @PostMapping("/create")
+    @Operation(summary = "관리자 계정 생성 API", description = "아이디와 비밀번호를 설정하여 관리자 계정을 생성합니다.")
+    public ResponseEntity<CommonResponse<CreateLoginIdResponseDto>> createAdmin(
+            @RequestBody CreateLoginIdRequestDto request
+    ) {
+        if(!adminSecretKey.equals((request.getSecretKey()))){
+            return ResponseEntity.status(403).body(CommonResponse.failure("관리자 시크릿 키가 틀립니다."));
+        }
+
+        CreateLoginIdResponseDto response = adminService.createAdmin(request);
+        return ResponseEntity.ok(CommonResponse.success("관리자 계정 생성 성공!", response));
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "관리자 계정 삭제 API", description = "아이디와 비밀번호를 입력하여 계정을 삭제합니다.")
+    public ResponseEntity deleteAdmin(
+            @RequestBody DeleteLoginIdRequestDto request
+    ) {
+        if(!adminSecretKey.equals((request.getSecretKey()))){
+            return ResponseEntity.status(403).body(CommonResponse.failure("관리자 시크릿 키가 틀립니다."));
+        }
+
+        adminService.deleteAdmin(request.getLoginId(), request.getPassword());
+        return ResponseEntity.ok(CommonResponse.success("관리자 계정 삭제 성공!"));
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/request/CreateLoginIdRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/request/CreateLoginIdRequestDto.java
@@ -1,0 +1,18 @@
+package com.mallan.yujeongran.icebreaking.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class CreateLoginIdRequestDto {
+
+    @Schema(description = "ADMIN_SECRET_KEY")
+    private String secretKey;
+
+    @Schema(description = "로그인 아이디", example = "MallanAdmin")
+    private String loginId;
+
+    @Schema(description = "비밀번호", example = "mallan-mallan")
+    private String password;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/request/DeleteLoginIdRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/request/DeleteLoginIdRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.admin.dto.request;
+
+import lombok.Getter;
+
+@Getter
+public class DeleteLoginIdRequestDto {
+
+    private String secretKey;
+    private String loginId;
+    private String password;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/response/CreateLoginIdResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/response/CreateLoginIdResponseDto.java
@@ -1,0 +1,13 @@
+package com.mallan.yujeongran.icebreaking.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class CreateLoginIdResponseDto {
+
+    private String loginId;
+    private String password;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/enitity/Admin.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/enitity/Admin.java
@@ -1,0 +1,34 @@
+package com.mallan.yujeongran.icebreaking.admin.enitity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Data
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "admin")
+@Builder
+public class Admin {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "account", nullable = false)
+    private String loginId;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/enitity/ManagementInfo.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/enitity/ManagementInfo.java
@@ -1,0 +1,55 @@
+package com.mallan.yujeongran.icebreaking.admin.enitity;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "management_info")
+public class ManagementInfo {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "total_game_count", nullable = false)
+    private int totalGameCount;
+
+    @Column(name = "total_user_count", nullable = false)
+    private int totalUserCount;
+
+    @Column(name = "total_review_count", nullable = false)
+    private int totalReviewCount;
+
+    @Column(name = "average_grade", nullable = false)
+    private float averageGrade;
+
+    @Column(name = "liar_total_count", nullable = false)
+    private int liarTotalCount;
+
+    @Column(name = "balance_total_count", nullable = false)
+    private int balanceTotalCount;
+
+    @Column(name = "question_total_count", nullable = false)
+    private int questionTotalCount;
+
+    @Column(name = "coin_total_count", nullable = false)
+    private int coinTotalCount;
+
+    @Column(name = "monthly_review_count", nullable = false)
+    private int monthlyReviewCount;
+
+    @Column(name = "updated_at", nullable = false)
+    private LocalDateTime updatedAt;
+
+    @PrePersist
+    protected void OnUpdate() {
+        this.updatedAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/repository/AdminRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/repository/AdminRepository.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.admin.repository;
+
+import com.mallan.yujeongran.icebreaking.admin.enitity.Admin;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface AdminRepository extends JpaRepository<Admin, Long> {
+
+    Optional<Admin> findByLoginId(String loginId);
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/repository/ManagementInfoRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/repository/ManagementInfoRepository.java
@@ -1,0 +1,8 @@
+//package com.mallan.yujeongran.icebreaking.admin.repository;
+//
+//import org.springframework.data.jpa.repository.JpaRepository;
+//import org.springframework.stereotype.Repository;
+//
+//@Repository
+//public interface ManagementInfoRepository extends JpaRepository<> {
+//}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/AdminService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/AdminService.java
@@ -1,0 +1,54 @@
+package com.mallan.yujeongran.icebreaking.admin.service;
+
+import com.mallan.yujeongran.icebreaking.admin.dto.request.CreateLoginIdRequestDto;
+import com.mallan.yujeongran.icebreaking.admin.dto.response.CreateLoginIdResponseDto;
+import com.mallan.yujeongran.icebreaking.admin.enitity.Admin;
+import com.mallan.yujeongran.icebreaking.admin.repository.AdminRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class AdminService {
+
+    private final AdminRepository adminRepository;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public CreateLoginIdResponseDto createAdmin(CreateLoginIdRequestDto request) {
+        if (adminRepository.findByLoginId(request.getLoginId()).isPresent()) {
+            throw new IllegalArgumentException("이미 존재하는 아이디입니다.");
+        }
+
+        String encodedPassword = passwordEncoder.encode(request.getPassword());
+
+        Admin admin = Admin.builder()
+                .loginId(request.getLoginId())
+                .password(encodedPassword)
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Admin saved = adminRepository.save(admin);
+
+        return CreateLoginIdResponseDto.builder()
+                .loginId(saved.getLoginId())
+                .password("설정한 비밀번호를 BCrypt로 암호화했습니다.")
+                .build();
+    }
+
+    public void deleteAdmin(String loginId, String password) {
+        Admin admin = adminRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new IllegalArgumentException("삭제 요청한 아이디가 없습니디."));
+
+        if (!passwordEncoder.matches(password, admin.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        adminRepository.delete(admin);
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/ManagementInfoService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/ManagementInfoService.java
@@ -1,0 +1,11 @@
+package com.mallan.yujeongran.icebreaking.admin.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ManagementInfoService {
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/liar_game/entity/LiarPlayer.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/liar_game/entity/LiarPlayer.java
@@ -3,6 +3,8 @@ package com.mallan.yujeongran.icebreaking.liar_game.entity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Table(name = "liar_player")
 @Data
@@ -27,5 +29,13 @@ public class LiarPlayer {
 
     @Column(name = "profileImage", nullable = false)
     private String profileImage;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreated(){
+        this.createdAt = LocalDateTime.now();
+    }
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/controller/ReviewController.java
@@ -3,15 +3,15 @@ package com.mallan.yujeongran.icebreaking.review.controller;
 import com.mallan.yujeongran.common.model.CommonResponse;
 import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewRequestDto;
 import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewResponseDto;
+import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewStatsResponseDto;
 import com.mallan.yujeongran.icebreaking.review.service.ReviewService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequestMapping("/reviews")
@@ -40,6 +40,18 @@ public class ReviewController {
     ) {
         ReviewResponseDto reviewResponseDto = reviewService.createReview(request);
         return ResponseEntity.ok(CommonResponse.success("리뷰 작성 성공!", reviewResponseDto));
+    }
+
+    @GetMapping("/recent")
+    @Operation(summary = "최근 2건의 리류 조회 API", description = "최근 리뷰 2건을 조회합니다.")
+    public ResponseEntity<CommonResponse<List<ReviewResponseDto>>> getRecentReviews() {
+        return ResponseEntity.ok(CommonResponse.success("최근 리뷰 2건 조회", reviewService.getRecentReviews()));
+    }
+
+    @GetMapping("/stats")
+    @Operation(summary = "리뷰 통계 조회 API", description = "총 후기 수, 평균 평점, 이번달 리뷰 수를 한번에 조회합니다.")
+    public ResponseEntity<CommonResponse<ReviewStatsResponseDto>> getReviewStats() {
+        return ResponseEntity.ok(CommonResponse.success("리뷰 통계 조회 성공", reviewService.getReviewStats()));
     }
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/controller/ReviewController.java
@@ -1,0 +1,45 @@
+package com.mallan.yujeongran.icebreaking.review.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewRequestDto;
+import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewResponseDto;
+import com.mallan.yujeongran.icebreaking.review.service.ReviewService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/reviews")
+@RequiredArgsConstructor
+@Tag(name = "Review API", description = "리뷰 작성 관련 API")
+public class ReviewController {
+
+    private final ReviewService reviewService;
+
+    @PostMapping
+    @Operation(
+            summary = "리뷰 작성 API",
+            description =
+        """
+        게임, 닉네임, 평점, 내용을 입력해서 리뷰를 작성합니다.
+
+        🔹 게임 종류는 다음 중 하나를 입력하세요:
+        - LIAR_GAME
+        - BALANCE_GAME
+        - OPEN_QUESTION_GAME
+        - COIN_TRUTH_GAME
+        """
+    )
+    public ResponseEntity<CommonResponse<ReviewResponseDto>> createReview(
+            @RequestBody ReviewRequestDto request
+    ) {
+        ReviewResponseDto reviewResponseDto = reviewService.createReview(request);
+        return ResponseEntity.ok(CommonResponse.success("리뷰 작성 성공!", reviewResponseDto));
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/request/ReviewRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/request/ReviewRequestDto.java
@@ -1,0 +1,27 @@
+package com.mallan.yujeongran.icebreaking.review.dto.request;
+
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ReviewRequestDto {
+
+    @Schema(
+            description = "게임 종류 (LIAR_GAME, BALANCE_GAME, OPEN_QUESTION_GAME, COIN_TRUTH_GAME)",
+            example = "LIAR_GAME"
+    )
+    private GameType gameType;
+
+    @Schema(description = "닉네임", example = "뜨거운감자")
+    private String nickname;
+
+    @Schema(description = "평점(1~5 정수)", example = "5")
+    private int grade;
+
+    @Schema(description = "리뷰 내용", example = "너무 재밌어요!")
+    private String content;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/response/ReviewResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/response/ReviewResponseDto.java
@@ -1,0 +1,16 @@
+package com.mallan.yujeongran.icebreaking.review.dto.response;
+
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewResponseDto {
+
+    private GameType gameType;
+    private String nickname;
+    private int grade;
+    private String content;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/response/ReviewStatsResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/response/ReviewStatsResponseDto.java
@@ -1,0 +1,14 @@
+package com.mallan.yujeongran.icebreaking.review.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ReviewStatsResponseDto {
+
+    private int totalReviewCount;
+    private float averageGrade;
+    private int monthlyReviewCount;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/enitity/Review.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/enitity/Review.java
@@ -1,0 +1,42 @@
+package com.mallan.yujeongran.icebreaking.review.enitity;
+
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Table(name = "review")
+@Data
+@Builder
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "game_type", nullable = false)
+    private GameType gameType;
+
+    @Column(name = "nickname", nullable = false)
+    private  String nickname;
+
+    @Column(name = "grade", nullable = false)
+    private  int grade;
+
+    @Column(name = "content",nullable = false)
+    private  String content;
+
+    @Column(name = "created_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void OnCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/enums/GameType.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/enums/GameType.java
@@ -1,0 +1,20 @@
+package com.mallan.yujeongran.icebreaking.review.enums;
+
+public enum GameType {
+
+    LIAR_GAME("라이어 게임"),
+    BALANCE_GAME("밸런스 게임"),
+    OPEN_QUESTION_GAME("오픈 퀘스천 게임"),
+    COIN_TRUTH_GAME("동전 진실 게임");
+
+    private final String korean;
+
+    GameType(String korean){
+        this.korean = korean;
+    }
+
+    public String getKorean() {
+        return korean;
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/repository/ReviewRepository.java
@@ -1,0 +1,9 @@
+package com.mallan.yujeongran.icebreaking.review.repository;
+
+import com.mallan.yujeongran.icebreaking.review.enitity.Review;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/repository/ReviewRepository.java
@@ -2,8 +2,22 @@ package com.mallan.yujeongran.icebreaking.review.repository;
 
 import com.mallan.yujeongran.icebreaking.review.enitity.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface ReviewRepository extends JpaRepository<Review, Long> {
+
+    @Query("SELECT AVG(r.grade) FROM Review r")
+    Float findAverageGrade();
+
+    @Query("SELECT COUNT(r) FROM Review r WHERE YEAR(r.createdAt) = :year AND MONTH(r.createdAt) = :month")
+    int countReviewsByMonth(@Param("year") int year, @Param("month") int month);
+
+    List<Review> findTop2ByOrderByCreatedAtDesc();
+
+
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/service/ReviewService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/service/ReviewService.java
@@ -2,6 +2,7 @@ package com.mallan.yujeongran.icebreaking.review.service;
 
 import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewRequestDto;
 import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewResponseDto;
+import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewStatsResponseDto;
 import com.mallan.yujeongran.icebreaking.review.enitity.Review;
 import com.mallan.yujeongran.icebreaking.review.repository.ReviewRepository;
 import jakarta.transaction.Transactional;
@@ -9,6 +10,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional
@@ -35,4 +38,30 @@ public class ReviewService {
                 .content(saved.getContent())
                 .build();
     }
+
+    public List<ReviewResponseDto> getRecentReviews() {
+        return reviewRepository.findTop2ByOrderByCreatedAtDesc()
+                .stream()
+                .map(r -> ReviewResponseDto.builder()
+                        .gameType(r.getGameType())
+                        .nickname(r.getNickname())
+                        .grade(r.getGrade())
+                        .content(r.getContent())
+                        .build())
+                .toList();
+    }
+
+    public ReviewStatsResponseDto getReviewStats() {
+        LocalDateTime now = LocalDateTime.now();
+
+        Float rawAverage = Optional.ofNullable(reviewRepository.findAverageGrade()).orElse(0.0f);
+        float roundedAverage = Math.round(rawAverage * 10) / 10.0f;
+
+        return ReviewStatsResponseDto.builder()
+                .totalReviewCount((int) reviewRepository.count())
+                .averageGrade(roundedAverage)
+                .monthlyReviewCount(reviewRepository.countReviewsByMonth(now.getYear(), now.getMonthValue()))
+                .build();
+    }
+
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/service/ReviewService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/service/ReviewService.java
@@ -1,0 +1,38 @@
+package com.mallan.yujeongran.icebreaking.review.service;
+
+import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewRequestDto;
+import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewResponseDto;
+import com.mallan.yujeongran.icebreaking.review.enitity.Review;
+import com.mallan.yujeongran.icebreaking.review.repository.ReviewRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ReviewService {
+
+    private final ReviewRepository reviewRepository;
+
+    public ReviewResponseDto createReview(ReviewRequestDto request) {
+        Review review = Review.builder()
+                .gameType(request.getGameType())
+                .nickname(request.getNickname())
+                .grade(request.getGrade())
+                .content(request.getContent())
+                .createdAt(LocalDateTime.now())
+                .build();
+
+        Review saved = reviewRepository.save(review);
+
+        return ReviewResponseDto.builder()
+                .gameType(saved.getGameType())
+                .nickname(saved.getNickname())
+                .grade(saved.getGrade())
+                .content(saved.getContent())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📋 Summary

> - closes #53
**관리자 계정 관련 기능을 구현합니다.**

## ✅ Tasks

- 관리자의 계정을 생성시에 관리자 시크릿 키를 인증 받아 관리자의 계정을 생성합니다.

## ✏️ To Reviewer

관리자 전용 페이지를 이용하기에 앞서 검증된 계정을 생성하는 기능을 구현합니다.

## 📷 Screenshot

<img width="475" alt="스크린샷 2025-06-17 오전 1 22 07" src="https://github.com/user-attachments/assets/c532604e-28c8-450c-98f7-1a2196870412" />
