### PR TITLE
[#59] 라이어 게임 - (게임 시작 전) 방 퇴장 기능 구현

### DIFF
--- a/frontend/src/api/roomExitApi.ts
+++ b/frontend/src/api/roomExitApi.ts
@@ -1,0 +1,13 @@
+import { api } from '../utils/api';
+
+export const roomExitApi = async (roomCode: string, playerId: string) => {
+  try {
+    const res = await api.post(`/liar/room/${roomCode}/exit`, {
+      playerId,
+    });
+    console.log('퇴장 요청 성공', res);
+    return res;
+  } catch (error) {
+    console.error('퇴장 요청 실패');
+  }
+};

--- a/frontend/src/components/common/CharacterSet.tsx
+++ b/frontend/src/components/common/CharacterSet.tsx
@@ -63,7 +63,11 @@ function CharacterSet({ isGuest }: { isGuest: boolean }) {
         navigate(`/liar/lobby/${roomCode}`);
       } else {
         playData = await createPlayerApi(nickname, profileImg);
+        const playerId = playData.data.playerId;
 
+        if (playerId) {
+          localStorage.setItem('playerId', playerId);
+        }
         navigate(`/liar/lobby/${playData.data.roomCode}`);
       }
       console.log(playData);

--- a/frontend/src/components/common/gameTitle/LiarGameTitle.tsx
+++ b/frontend/src/components/common/gameTitle/LiarGameTitle.tsx
@@ -31,6 +31,12 @@ const ExitBtn = styled.button`
   font-size: 22px;
   font-family: 'JejuDoldam';
   transform: translateY(-50%);
+
+  ${media.small`
+    top:0;
+    transform:inherit;
+    font-size:12px;
+  `}
 `;
 
 function LiarGameTitle({ title }: { title: string }) {

--- a/frontend/src/components/common/gameTitle/LiarGameTitle.tsx
+++ b/frontend/src/components/common/gameTitle/LiarGameTitle.tsx
@@ -1,5 +1,12 @@
 import styled from 'styled-components';
 import media from '../../../styles/breakPoint';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { roomExitApi } from '../../../api/roomExitApi';
+import { getRoomInfoApi } from '../../../api/getRoomInfoApi';
+
+const GameTitleWrap = styled.div`
+  position: relative;
+`;
 
 const GameTitle = styled.h1`
   padding: 70px 0;
@@ -15,8 +22,50 @@ const GameTitle = styled.h1`
   `}
 `;
 
+const ExitBtn = styled.button`
+  position: absolute;
+  top: 50%;
+  left: 0;
+  color: #fff;
+  height: 50px;
+  font-size: 22px;
+  font-family: 'JejuDoldam';
+  transform: translateY(-50%);
+`;
+
 function LiarGameTitle({ title }: { title: string }) {
-  return <GameTitle>{title}</GameTitle>;
+  const location = useLocation();
+  const navigate = useNavigate();
+  const isLobbyPage = location.pathname.startsWith('/liar/lobby/');
+  const { roomCode } = useParams();
+  const playerId = localStorage.getItem('playerId');
+
+  const handleExit = () => {
+    if (!roomCode) return;
+
+    // 퇴장 api 호출
+    roomExitApi(roomCode ?? '', playerId ?? '');
+
+    // 페이지 이동 (초기화)
+    navigate('/liar/room/');
+
+    // 방 정보 퇴장시 다시 반영하기
+    getRoomInfoApi(roomCode ?? '');
+
+    // localStorage 초기화
+    localStorage.removeItem('playerId');
+  };
+
+  return (
+    <GameTitleWrap>
+      <GameTitle>{title}</GameTitle>
+      {isLobbyPage && (
+        <ExitBtn type="button" onClick={handleExit}>
+          &lt; 방 나가기
+        </ExitBtn>
+      )}
+    </GameTitleWrap>
+  );
 }
 
 export default LiarGameTitle;

--- a/frontend/src/components/liar/GameSetCon.tsx
+++ b/frontend/src/components/liar/GameSetCon.tsx
@@ -50,7 +50,6 @@ const Select = styled.select`
 `;
 
 function GameSetCon() {
-  const playerId = localStorage.getItem('playerId');
   const { roomCode } = useParams();
   const [topics, setTopics] = useState<TopicType[]>([]);
   const [roomInfo, setRoomInfo] = useState<RoomInfo | null>(null);
@@ -84,8 +83,11 @@ function GameSetCon() {
     roomInfo();
   }, [roomCode]);
 
+  const isHost =
+    roomInfo?.data?.players[0].playerId === localStorage.getItem('playerId');
+  console.log(isHost);
   const handleChnage = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (playerId) {
+    if (!isHost) {
       alert('해당 설정은 방장 권한이 필요합니다.');
       return;
     }
@@ -109,7 +111,7 @@ function GameSetCon() {
 
   // 라운드 설정
   const handleRoundChange = (e: React.ChangeEvent<HTMLSelectElement>) => {
-    if (playerId) {
+    if (!isHost) {
       alert('해당 설정은 방장 권한이 필요합니다.');
       return;
     }

--- a/frontend/src/components/liar/GameSetCon.tsx
+++ b/frontend/src/components/liar/GameSetCon.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import media from '../../styles/breakPoint';
 import { getTopicApi } from '../../api/getTopicApi';
 import { selectRoomTopicApi } from '../../api/selectRoomTopicApi';
 import { getRoomInfoApi } from '../../api/getRoomInfoApi';
@@ -47,6 +48,10 @@ const Select = styled.select`
   border-radius: ${({ theme }) => theme.borderRadSm};
   border: 1px solid ${({ theme }) => theme.border};
   background: #fff url('/image/select_arw.svg') no-repeat center right 10px;
+
+  ${media.small`
+    background-size:18px;
+  `}
 `;
 
 function GameSetCon() {

--- a/frontend/src/components/liar/PlayerListTabCon.tsx
+++ b/frontend/src/components/liar/PlayerListTabCon.tsx
@@ -44,6 +44,10 @@ const CodeCopy = styled.button`
     margin-left: 4px;
     vertical-align: middle;
   }
+
+  ${media.small`
+    font-size:14px;
+  `}
 `;
 
 const PlayerList = styled.ul`


### PR DESCRIPTION
## 📋 Summary

> - #59 
> - closes #59 

게임 시작 전 호스트와 게스트 모두 방을 자유롭게 퇴장할 수 있는 기능을 구현했습니다.

## ✅ Tasks

- 퇴장시 닉네임 설정 화면으로 이동 처리  
- 방 나가기 버튼 추가

## ✏️ To Reviewer

현재는 사용자가 방을 나가더라도 다른 참여자에게 실시간으로 반영되지 않습니다.  
웹소켓 설계가 완료되면 해당 부분을 실시간으로 업데이트 되도록 수정할 예정입니다.
