### PR TITLE
[#62] 세션 기반 로그인 기능 구현

### DIFF
--- a/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
+++ b/backend/src/main/java/com/mallan/yujeongran/config/SecurityConfig.java
@@ -27,7 +27,8 @@ public class SecurityConfig {
                     var config = new org.springframework.web.cors.CorsConfiguration();
                     config.setAllowedOrigins(List.of(
                             "http://localhost:5173",
-                            "https://port-0-mallan-mbae24le7f0ebadb.sel4.cloudtype.app"
+                            "https://port-0-mallan-mbae24le7f0ebadb.sel4.cloudtype.app",
+                            "http://localhost:3000"
                     ));
                     config.setAllowedMethods(List.of("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
                     config.setAllowedHeaders(List.of("*"));
@@ -35,21 +36,26 @@ public class SecurityConfig {
                     return config;
                 }))
                 .authorizeHttpRequests(auth -> auth
-                        // Swagger 허용
-                        .requestMatchers(
-                                "/v3/api-docs/**",
-                                "/swagger-ui/**",
-                                "/swagger-ui.html"
-                        ).permitAll()
+//                        // 로그인된 관리자만 허용되는 Path
+//                        .requestMatchers(
+//                                "/reviews/all",
+//                                "/reviews/delete"
+//
+//                        ).authenticated()
 
-                        // 게임 관련 API Path 허용
+                        // 게임 관련 & Swagger API Path 허용
                         .requestMatchers(
                                 "/liar/**",
                                 "/balance/**",
                                 "/coin/**",
                                 "/question/**",
+                                "/review",
                                 "/reviews/**",
-                                "/admin/**"
+                                "/admin/**",
+                                "/management/**",
+                                "/v3/api-docs/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html"
                         ).permitAll()
 
                         // 그 외에는 인증 필요

--- a/backend/src/main/java/com/mallan/yujeongran/config/WebMvcConfig.java
+++ b/backend/src/main/java/com/mallan/yujeongran/config/WebMvcConfig.java
@@ -1,11 +1,40 @@
 package com.mallan.yujeongran.config;
 
+import com.mallan.yujeongran.icebreaking.admin.interceptor.AdminSessionInterceptor;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@RequiredArgsConstructor
 public class WebMvcConfig implements WebMvcConfigurer {
+
+    private final AdminSessionInterceptor adminSessionInterceptor;
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry){
+        registry.addInterceptor(adminSessionInterceptor)
+                // Protected Path By Session
+                .addPathPatterns(
+                        "/admin/**",
+                        "/management/**",
+                        "/reviews/**"
+                )
+                .excludePathPatterns(
+                        "/admin/login",
+                        "/admin/create",
+                        "/admin/delete",
+                        "/admin/logout",
+//                        "/reviews/all",
+//                        "/reviews/delete",
+//                        "/reviews/all/**",
+//                        "/reviews/delete/**",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**"
+                );
+    }
 
     @Override
     public void addResourceHandlers(ResourceHandlerRegistry registry) {
@@ -13,6 +42,5 @@ public class WebMvcConfig implements WebMvcConfigurer {
                 .addResourceHandler("/common/profile_image/**")
                 .addResourceLocations("classpath:/static/common/profile_image/");
     }
-
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/controller/AdminController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/controller/AdminController.java
@@ -1,12 +1,17 @@
 package com.mallan.yujeongran.icebreaking.admin.controller;
 
 import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.admin.dto.request.AdminLoginRequestDto;
 import com.mallan.yujeongran.icebreaking.admin.dto.request.CreateLoginIdRequestDto;
 import com.mallan.yujeongran.icebreaking.admin.dto.request.DeleteLoginIdRequestDto;
+import com.mallan.yujeongran.icebreaking.admin.dto.response.AdminLoginResponseDto;
 import com.mallan.yujeongran.icebreaking.admin.dto.response.CreateLoginIdResponseDto;
 import com.mallan.yujeongran.icebreaking.admin.service.AdminService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.ResponseEntity;
@@ -47,6 +52,46 @@ public class AdminController {
 
         adminService.deleteAdmin(request.getLoginId(), request.getPassword());
         return ResponseEntity.ok(CommonResponse.success("관리자 계정 삭제 성공!"));
+    }
+
+    @PostMapping("/login")
+    @Operation(summary = "관리자 로그인 API", description = "아이디와 비밀번호를 입력하여 관라지 계정으로 로그인합니다.")
+    public ResponseEntity<CommonResponse<AdminLoginResponseDto>> loginAdmin(
+            @RequestBody AdminLoginRequestDto request,
+            HttpSession session
+    ){
+        AdminLoginResponseDto response = adminService.login(request, session);
+        return ResponseEntity.ok(CommonResponse.success("로그인 성공!", response));
+    }
+
+    @PostMapping("/logout")
+    @Operation(summary = "관리자 로그아웃 API", description = "관리자 세션을 종료합니다.")
+    public ResponseEntity<CommonResponse<Void>> logoutAdmin(HttpServletResponse response, HttpSession session) {
+        // Delete All Sessions
+        session.invalidate();
+
+        // Delete JSESSIONID Cookie
+        Cookie cookie = new Cookie("JSESSIONID", null);
+        cookie.setPath("/");
+        cookie.setMaxAge(0);
+        cookie.setHttpOnly(true);
+        response.addCookie(cookie);
+
+        return ResponseEntity.ok(CommonResponse.success("로그아웃 성공!"));
+    }
+
+    @GetMapping("/me")
+    @Operation(summary = "세션 인증 여부 확인 API", description = "관라지만이 접근 가능한 페이지에서 해당 API를 이용하려 접근 가능 여부를 체크합니다.")
+    public ResponseEntity<?> getSessionAdmin(HttpSession session) {
+        String loginId = (String) session.getAttribute("ADMIN_LOGIN_ID");
+        if (loginId == null) {
+            return ResponseEntity.status(401).body(CommonResponse.failure("로그인이 필요합니다."));
+        }
+
+        return ResponseEntity.ok(CommonResponse.success("세션 유지 중", AdminLoginResponseDto.builder()
+                .loginId(loginId)
+                .message("세션 유효함")
+                .build()));
     }
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/controller/ManagementInfoController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/controller/ManagementInfoController.java
@@ -1,0 +1,29 @@
+package com.mallan.yujeongran.icebreaking.admin.controller;
+
+import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.admin.dto.response.ManagementInfoResponseDto;
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/management")
+@Tag(name = "Management Info API", description = "관리자 관리 정보 출력 API")
+public class ManagementInfoController {
+
+    private final ManagementInfoService managementInfoService;
+
+    @GetMapping
+    @Operation(summary = "관리 정보 출력 API", description = "대시보드에 필요한 정보를 출력합니다.")
+    public ResponseEntity<CommonResponse<ManagementInfoResponseDto>> getDashboardInfo() {
+        ManagementInfoResponseDto info = managementInfoService.getLatestInfo();
+        return ResponseEntity.ok(CommonResponse.success("대시보드 정보 조회 성공!", info));
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/request/AdminLoginRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/request/AdminLoginRequestDto.java
@@ -1,0 +1,15 @@
+package com.mallan.yujeongran.icebreaking.admin.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class AdminLoginRequestDto {
+
+    @Schema(description = "로그인 아이디", example = "mallanadmin")
+    private String loginId;
+
+    @Schema(description = "비밀번호", example = "mallanmallan")
+    private String password;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/response/AdminLoginResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/response/AdminLoginResponseDto.java
@@ -1,0 +1,13 @@
+package com.mallan.yujeongran.icebreaking.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminLoginResponseDto {
+
+    private String loginId;
+    private String message;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/response/ManagementInfoResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/dto/response/ManagementInfoResponseDto.java
@@ -1,0 +1,20 @@
+package com.mallan.yujeongran.icebreaking.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class ManagementInfoResponseDto {
+
+    private int totalGameCount;
+    private int totalUserCount;
+    private int totalReviewCount;
+    private float averageGrade;
+    private int liarTotalCount;
+    private int balanceTotalCount;
+    private int questionTotalCount;
+    private int coinTotalCount;
+    private int monthlyReviewCount;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/enitity/ManagementInfo.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/enitity/ManagementInfo.java
@@ -48,6 +48,7 @@ public class ManagementInfo {
     private LocalDateTime updatedAt;
 
     @PrePersist
+    @PreUpdate
     protected void OnUpdate() {
         this.updatedAt = LocalDateTime.now();
     }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/interceptor/AdminSessionInterceptor.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/interceptor/AdminSessionInterceptor.java
@@ -1,0 +1,26 @@
+package com.mallan.yujeongran.icebreaking.admin.interceptor;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import java.io.IOException;
+
+@Component
+public class AdminSessionInterceptor implements HandlerInterceptor { // Check Session Key Exists
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws IOException {
+        HttpSession session = request.getSession(false);
+        if (session == null || session.getAttribute("ADMIN_LOGIN_ID") == null) {
+            response.setContentType("application/json");
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().write("{\"status\":401, \"message\":\"세션이 없습니다. 로그인 해주세요.\"}");
+            return false;
+        }
+        return true;
+    }
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/repository/ManagementInfoRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/repository/ManagementInfoRepository.java
@@ -1,8 +1,14 @@
-//package com.mallan.yujeongran.icebreaking.admin.repository;
-//
-//import org.springframework.data.jpa.repository.JpaRepository;
-//import org.springframework.stereotype.Repository;
-//
-//@Repository
-//public interface ManagementInfoRepository extends JpaRepository<> {
-//}
+package com.mallan.yujeongran.icebreaking.admin.repository;
+
+import com.mallan.yujeongran.icebreaking.admin.enitity.ManagementInfo;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface ManagementInfoRepository extends JpaRepository<ManagementInfo, Long> {
+
+    Optional<ManagementInfo> findTopByOrderByUpdatedAtDesc();
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/AdminService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/AdminService.java
@@ -1,9 +1,12 @@
 package com.mallan.yujeongran.icebreaking.admin.service;
 
+import com.mallan.yujeongran.icebreaking.admin.dto.request.AdminLoginRequestDto;
 import com.mallan.yujeongran.icebreaking.admin.dto.request.CreateLoginIdRequestDto;
+import com.mallan.yujeongran.icebreaking.admin.dto.response.AdminLoginResponseDto;
 import com.mallan.yujeongran.icebreaking.admin.dto.response.CreateLoginIdResponseDto;
 import com.mallan.yujeongran.icebreaking.admin.enitity.Admin;
 import com.mallan.yujeongran.icebreaking.admin.repository.AdminRepository;
+import jakarta.servlet.http.HttpSession;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
@@ -49,6 +52,22 @@ public class AdminService {
         }
 
         adminRepository.delete(admin);
+    }
+
+    public AdminLoginResponseDto login(AdminLoginRequestDto request, HttpSession session){
+        Admin admin = adminRepository.findByLoginId(request.getLoginId())
+                .orElseThrow(() -> new IllegalArgumentException("해당 아이디는 존재하지 않습니다."));
+
+        if(!passwordEncoder.matches(request.getPassword(), admin.getPassword())){
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        session.setAttribute("ADMIN_LOGIN_ID", request.getLoginId());
+
+        return AdminLoginResponseDto.builder()
+                .loginId(request.getLoginId())
+                .message("관리자 계정으로 로그인 하였습니다.")
+                .build();
     }
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/ManagementInfoService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/admin/service/ManagementInfoService.java
@@ -1,11 +1,87 @@
 package com.mallan.yujeongran.icebreaking.admin.service;
 
+import com.mallan.yujeongran.icebreaking.admin.dto.response.ManagementInfoResponseDto;
+import com.mallan.yujeongran.icebreaking.admin.enitity.ManagementInfo;
+import com.mallan.yujeongran.icebreaking.admin.repository.ManagementInfoRepository;
+import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewStatsResponseDto;
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
 
 @Service
 @Transactional
 @RequiredArgsConstructor
 public class ManagementInfoService {
+
+    private final ManagementInfoRepository managementInfoRepository;
+
+    public void incrementGameCount(GameType type) {
+        ManagementInfo info = managementInfoRepository.findTopByOrderByUpdatedAtDesc()
+                .orElseGet(() -> managementInfoRepository.save(ManagementInfo.builder().build()));
+
+        info.setTotalGameCount(info.getTotalGameCount() + 1);
+
+        switch (type) {
+            case LIAR_GAME -> info.setLiarTotalCount(info.getLiarTotalCount() + 1);
+            case BALANCE_GAME -> info.setBalanceTotalCount(info.getBalanceTotalCount() + 1);
+            case OPEN_QUESTION_GAME -> info.setQuestionTotalCount(info.getQuestionTotalCount() + 1);
+            case COIN_TRUTH_GAME -> info.setCoinTotalCount(info.getCoinTotalCount() + 1);
+        }
+
+        managementInfoRepository.save(info);
+    }
+
+    public void incrementUserCount(GameType type) {
+        ManagementInfo info = managementInfoRepository.findTopByOrderByUpdatedAtDesc()
+                .orElseGet(() -> managementInfoRepository.save(ManagementInfo.builder().build()));
+
+        switch (type) {
+            case LIAR_GAME, BALANCE_GAME, OPEN_QUESTION_GAME, COIN_TRUTH_GAME -> info.setTotalUserCount(info.getTotalUserCount() + 1);
+        }
+
+        managementInfoRepository.save(info);
+    }
+
+    public ManagementInfoResponseDto getLatestInfo() {
+        ManagementInfo info = managementInfoRepository.findTopByOrderByUpdatedAtDesc()
+                .orElseGet(() -> managementInfoRepository.save(ManagementInfo.builder()
+                        .totalGameCount(0)
+                        .totalUserCount(0)
+                        .totalReviewCount(0)
+                        .averageGrade(0)
+                        .liarTotalCount(0)
+                        .balanceTotalCount(0)
+                        .questionTotalCount(0)
+                        .coinTotalCount(0)
+                        .monthlyReviewCount(0)
+                        .build()));
+
+        return ManagementInfoResponseDto.builder()
+                .totalGameCount(info.getTotalGameCount())
+                .totalUserCount(info.getTotalUserCount())
+                .totalReviewCount(info.getTotalReviewCount())
+                .averageGrade(info.getAverageGrade())
+                .liarTotalCount(info.getLiarTotalCount())
+                .balanceTotalCount(info.getBalanceTotalCount())
+                .questionTotalCount(info.getQuestionTotalCount())
+                .coinTotalCount(info.getCoinTotalCount())
+                .monthlyReviewCount(info.getMonthlyReviewCount())
+                .build();
+    }
+
+    public void updateStatsFromReview(ReviewStatsResponseDto stats) {
+        ManagementInfo info = managementInfoRepository.findTopByOrderByUpdatedAtDesc()
+                .orElseThrow(() -> new IllegalStateException("관리 통계 정보가 없습니다."));
+
+        info.setTotalReviewCount(stats.getTotalReviewCount());
+        info.setAverageGrade(stats.getAverageGrade());
+        info.setMonthlyReviewCount(stats.getMonthlyReviewCount());
+
+        info.setUpdatedAt(LocalDateTime.now());
+        managementInfoRepository.save(info);
+    }
+
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/balance_game/service/BalanceGameService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/balance_game/service/BalanceGameService.java
@@ -1,5 +1,6 @@
 package com.mallan.yujeongran.icebreaking.balance_game.service;
 
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
 import com.mallan.yujeongran.icebreaking.balance_game.dto.request.BalanceCreateIngameQuestionRequestDto;
 import com.mallan.yujeongran.icebreaking.balance_game.dto.request.BalanceStartGameRequestDto;
 import com.mallan.yujeongran.icebreaking.balance_game.dto.request.BalanceSubmitAnswerRequestDto;
@@ -13,6 +14,7 @@ import com.mallan.yujeongran.icebreaking.balance_game.repository.BalanceFinalRes
 import com.mallan.yujeongran.icebreaking.balance_game.repository.BalanceQuestionRepository;
 import com.mallan.yujeongran.icebreaking.balance_game.repository.BalanceResultRepository;
 import com.mallan.yujeongran.icebreaking.balance_game.repository.BalanceRoomRepository;
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -35,6 +37,7 @@ public class BalanceGameService {
     private final BalancePlayerService balancePlayerService;
     private final RedisTemplate<String, String> redisTemplate;
     private final StringRedisTemplate stringRedisTemplate;
+    private final ManagementInfoService managementInfoService;
 
     public void startGame(String roomCode, BalanceStartGameRequestDto requestDto) {
         BalanceRoom room = balanceRoomRepository.findByRoomCode(roomCode)
@@ -56,6 +59,8 @@ public class BalanceGameService {
         for (BalanceQuestion q : selectedQuestions) {
             stringRedisTemplate.opsForList().rightPush(redisKey, q.getId().toString());
         }
+
+        managementInfoService.incrementGameCount(GameType.BALANCE_GAME);
 
         stringRedisTemplate.opsForValue().set("room:" + roomCode + ":currentQuestionIdx", "0");
 

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/balance_game/service/BalanceRoomService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/balance_game/service/BalanceRoomService.java
@@ -1,5 +1,6 @@
 package com.mallan.yujeongran.icebreaking.balance_game.service;
 
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
 import com.mallan.yujeongran.icebreaking.balance_game.dto.request.BalanceCreatePlayerRequestDto;
 import com.mallan.yujeongran.icebreaking.balance_game.dto.request.BalanceJoinRoomRequestDto;
 import com.mallan.yujeongran.icebreaking.balance_game.dto.request.BalanceUpdateQuestionCountRequestDto;
@@ -10,6 +11,7 @@ import com.mallan.yujeongran.icebreaking.balance_game.dto.response.BalanceRoomRe
 import com.mallan.yujeongran.icebreaking.balance_game.dto.response.BalanceWaitingRoomResponseDto;
 import com.mallan.yujeongran.icebreaking.balance_game.entity.BalanceRoom;
 import com.mallan.yujeongran.icebreaking.balance_game.repository.BalanceRoomRepository;
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -29,7 +31,7 @@ public class BalanceRoomService {
     private final BalanceRoomRepository balanceRoomRepository;
     private final BalancePlayerService balancePlayerService;
     private final RedisTemplate<String, String> redisTemplate;
-
+    private final ManagementInfoService managementInfoService;
 
     @Value("${BALANCE_ROOM_BASE_URL}")
     private String balanceRoomBaseUrl;
@@ -52,6 +54,8 @@ public class BalanceRoomService {
         balancePlayerService.createPlayer(hostId, requestDto.getNickname(), requestDto.getProfileImage());
         balancePlayerService.createRoom(roomCode, hostId);
 
+        managementInfoService.incrementUserCount(GameType.BALANCE_GAME);
+
         return BalanceRoomResponseDto.builder()
                 .playerId(hostId)
                 .roomCode(roomCode)
@@ -68,6 +72,8 @@ public class BalanceRoomService {
         BalanceRoom room = balanceRoomRepository.findByRoomCode(roomCode)
                 .orElseThrow(() -> new IllegalArgumentException("방이 존재하지 않습니다."));
         room.setPlayerCount(room.getPlayerCount() + 1);
+
+        managementInfoService.incrementUserCount(GameType.BALANCE_GAME);
 
         return BalanceJoinRoomResponseDto.builder()
                 .playerId(playerId)

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinPlayerService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinPlayerService.java
@@ -1,11 +1,13 @@
 package com.mallan.yujeongran.icebreaking.coin_game.service;
 
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinCreateRoomRequestDto;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinJoinRoomRequestDto;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinCreateRoomResponseDto;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinJoinRoomResponseDto;
 import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinRoom;
 import com.mallan.yujeongran.icebreaking.coin_game.repository.CoinRoomRepository;
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -23,6 +25,7 @@ public class CoinPlayerService {
 
     private final RedisTemplate<String, String> redisTemplate;
     private final CoinRoomRepository coinRoomRepository;
+    private final ManagementInfoService managementInfoService;
 
     @Value("${COIN_ROOM_BASE_URL}")
     private String coinRoomBaseUrl;
@@ -52,6 +55,8 @@ public class CoinPlayerService {
 
         coinRoomRepository.save(room);
 
+        managementInfoService.incrementUserCount(GameType.COIN_TRUTH_GAME);
+
         return CoinCreateRoomResponseDto.builder()
                 .roomCode(roomCode)
                 .hostId(playerId)
@@ -80,6 +85,8 @@ public class CoinPlayerService {
             room.setPlayerCount(current + 1);
             coinRoomRepository.save(room);
         });
+
+        managementInfoService.incrementUserCount(GameType.COIN_TRUTH_GAME);
 
         return CoinJoinRoomResponseDto.builder()
                 .playerId(playerId)

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinRoomService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/coin_game/service/CoinRoomService.java
@@ -1,5 +1,6 @@
 package com.mallan.yujeongran.icebreaking.coin_game.service;
 
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinExitRoomRequestDto;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinSetRoundRequestDto;
 import com.mallan.yujeongran.icebreaking.coin_game.dto.request.CoinStartGameRequestDto;
@@ -7,6 +8,7 @@ import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinWaitingPlaye
 import com.mallan.yujeongran.icebreaking.coin_game.dto.response.CoinWaitingRoomResponseDto;
 import com.mallan.yujeongran.icebreaking.coin_game.entity.CoinRoom;
 import com.mallan.yujeongran.icebreaking.coin_game.repository.CoinRoomRepository;
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -23,6 +25,7 @@ public class CoinRoomService {
     private final CoinGameService coinGameService;
     private final CoinRoomRepository coinRoomRepository;
     private final RedisTemplate<String, String> redisTemplate;
+    private final ManagementInfoService managementInfoService;
 
     public CoinWaitingRoomResponseDto getWaitingRoomInfo(String roomCode) {
         CoinRoom room = coinRoomRepository.findByRoomCode(roomCode)
@@ -69,6 +72,8 @@ public class CoinRoomService {
         if (!request.getPlayerId().equals(hostId)) {
             throw new IllegalArgumentException("방장만 게임을 시작할 수 있습니다.");
         }
+
+        managementInfoService.incrementGameCount(GameType.COIN_TRUTH_GAME);
 
         redisTemplate.opsForValue().set("coin:room:" + roomCode + ":started", "true", Duration.ofHours(24));
     }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/liar_game/service/LiarRoomService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/liar_game/service/LiarRoomService.java
@@ -1,5 +1,6 @@
 package com.mallan.yujeongran.icebreaking.liar_game.service;
 
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
 import com.mallan.yujeongran.icebreaking.liar_game.dto.request.*;
 import com.mallan.yujeongran.icebreaking.liar_game.dto.response.LiarGameResultResponseDto;
 import com.mallan.yujeongran.icebreaking.liar_game.dto.response.LiarPlayerInfoResponseDto;
@@ -8,6 +9,7 @@ import com.mallan.yujeongran.icebreaking.liar_game.entity.LiarRoom;
 import com.mallan.yujeongran.icebreaking.liar_game.entity.LiarWord;
 import com.mallan.yujeongran.icebreaking.liar_game.repository.LiarRoomRepository;
 import com.mallan.yujeongran.icebreaking.liar_game.repository.LiarWordRepository;
+import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -24,6 +26,7 @@ public class LiarRoomService {
     private final LiarRoomRepository liarRoomRepository;
     private final LiarWordRepository liarWordRepository;
     private final LiarPlayerService liarPlayerService;
+    private final ManagementInfoService managementInfoService;
 
     @Value("${LIAR_ROOM_BASE_URL}")
     private String liarRoomBaseUrl;
@@ -48,6 +51,9 @@ public class LiarRoomService {
         response.put("playerId", playerId);
         response.put("roomCode", roomCode);
         response.put("url", liarRoomBaseUrl + "/" + roomCode);
+
+        managementInfoService.incrementUserCount(GameType.LIAR_GAME);
+
         return response;
     }
 
@@ -86,6 +92,9 @@ public class LiarRoomService {
         Map<String, String> response = new HashMap<>();
         response.put("playerId", playerId);
         response.put("roomCode", roomCode);
+
+        managementInfoService.incrementUserCount(GameType.LIAR_GAME);
+
         return response;
     }
 
@@ -212,6 +221,8 @@ public class LiarRoomService {
 
         Collections.shuffle(allPlayerIds);
         List<String> liarIds = allPlayerIds.subList(0, liarCount);
+
+        managementInfoService.incrementGameCount(GameType.LIAR_GAME);
 
         liarPlayerService.assignLiars(roomCode, liarIds);
     }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/controller/ReviewController.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/controller/ReviewController.java
@@ -1,6 +1,8 @@
 package com.mallan.yujeongran.icebreaking.review.controller;
 
 import com.mallan.yujeongran.common.model.CommonResponse;
+import com.mallan.yujeongran.icebreaking.admin.service.ManagementInfoService;
+import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewDeleteRequestDto;
 import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewRequestDto;
 import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewResponseDto;
 import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewStatsResponseDto;
@@ -20,6 +22,7 @@ import java.util.List;
 public class ReviewController {
 
     private final ReviewService reviewService;
+    private final ManagementInfoService managementInfoService;
 
     @PostMapping
     @Operation(
@@ -39,13 +42,23 @@ public class ReviewController {
             @RequestBody ReviewRequestDto request
     ) {
         ReviewResponseDto reviewResponseDto = reviewService.createReview(request);
+
+        ReviewStatsResponseDto stats = reviewService.getReviewStats();
+        managementInfoService.updateStatsFromReview(stats);
+
         return ResponseEntity.ok(CommonResponse.success("리뷰 작성 성공!", reviewResponseDto));
     }
 
-    @GetMapping("/recent")
-    @Operation(summary = "최근 2건의 리류 조회 API", description = "최근 리뷰 2건을 조회합니다.")
-    public ResponseEntity<CommonResponse<List<ReviewResponseDto>>> getRecentReviews() {
-        return ResponseEntity.ok(CommonResponse.success("최근 리뷰 2건 조회", reviewService.getRecentReviews()));
+    @GetMapping("/recent/two")
+    @Operation(summary = "최근 2건의 리뷰 조회 API", description = "최근 리뷰 2건을 조회합니다.")
+    public ResponseEntity<CommonResponse<List<ReviewResponseDto>>> getRecentTwoReviews() {
+        return ResponseEntity.ok(CommonResponse.success("최근 리뷰 2건 조회", reviewService.getRecentTwoReviews()));
+    }
+
+    @GetMapping("/recent/three")
+    @Operation(summary = "최근 3건의 리뷰 조회 API", description = "최근 리뷰 3건을 조회합니다.")
+    public ResponseEntity<CommonResponse<List<ReviewResponseDto>>> getRecentThreeReviews() {
+        return ResponseEntity.ok(CommonResponse.success("최근 리뷰 2건 조회", reviewService.getRecentThreeReviews()));
     }
 
     @GetMapping("/stats")
@@ -53,5 +66,21 @@ public class ReviewController {
     public ResponseEntity<CommonResponse<ReviewStatsResponseDto>> getReviewStats() {
         return ResponseEntity.ok(CommonResponse.success("리뷰 통계 조회 성공", reviewService.getReviewStats()));
     }
+
+    @GetMapping("/all")
+    @Operation(summary = "전체 리뷰 조회 API (관리자 전용)", description = "모든 리뷰를 조회합니다.")
+    public ResponseEntity<CommonResponse<List<ReviewResponseDto>>> getAllReviews() {
+        return ResponseEntity.ok(CommonResponse.success("전체 리뷰 조회 성공", reviewService.getAllReviews()));
+    }
+
+    @DeleteMapping("/delete")
+    @Operation(summary = "리뷰 삭제 API (관리자 전용)", description = "특정 리뷰를 삭제합니다.")
+    public ResponseEntity<CommonResponse<Void>> deleteReview(
+            @RequestBody ReviewDeleteRequestDto request
+            ) {
+        reviewService.deleteReview(request);
+        return ResponseEntity.ok(CommonResponse.success("리뷰 삭제 성공", null));
+    }
+
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/request/ReviewDeleteRequestDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/request/ReviewDeleteRequestDto.java
@@ -1,0 +1,12 @@
+package com.mallan.yujeongran.icebreaking.review.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Getter;
+
+@Getter
+public class ReviewDeleteRequestDto {
+
+    @Schema(description = "리뷰 아이디", example = "1")
+    private Long reviewId;
+
+}

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/response/ReviewResponseDto.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/dto/response/ReviewResponseDto.java
@@ -1,8 +1,11 @@
 package com.mallan.yujeongran.icebreaking.review.dto.response;
 
+import com.mallan.yujeongran.icebreaking.review.enitity.Review;
 import com.mallan.yujeongran.icebreaking.review.enums.GameType;
 import lombok.Builder;
 import lombok.Getter;
+
+import java.time.LocalDateTime;
 
 @Getter
 @Builder
@@ -12,5 +15,16 @@ public class ReviewResponseDto {
     private String nickname;
     private int grade;
     private String content;
+    private LocalDateTime createdAt;
+
+    public static ReviewResponseDto from(Review review) {
+        return ReviewResponseDto.builder()
+                .gameType(review.getGameType())
+                .nickname(review.getNickname())
+                .grade(review.getGrade())
+                .content(review.getContent())
+                .createdAt(review.getCreatedAt())
+                .build();
+    }
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/repository/ReviewRepository.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/repository/ReviewRepository.java
@@ -18,6 +18,6 @@ public interface ReviewRepository extends JpaRepository<Review, Long> {
     int countReviewsByMonth(@Param("year") int year, @Param("month") int month);
 
     List<Review> findTop2ByOrderByCreatedAtDesc();
-
+    List<Review> findTop3ByOrderByCreatedAtDesc();
 
 }

--- a/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/service/ReviewService.java
+++ b/backend/src/main/java/com/mallan/yujeongran/icebreaking/review/service/ReviewService.java
@@ -1,5 +1,6 @@
 package com.mallan.yujeongran.icebreaking.review.service;
 
+import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewDeleteRequestDto;
 import com.mallan.yujeongran.icebreaking.review.dto.request.ReviewRequestDto;
 import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewResponseDto;
 import com.mallan.yujeongran.icebreaking.review.dto.response.ReviewStatsResponseDto;
@@ -39,8 +40,20 @@ public class ReviewService {
                 .build();
     }
 
-    public List<ReviewResponseDto> getRecentReviews() {
+    public List<ReviewResponseDto> getRecentTwoReviews() {
         return reviewRepository.findTop2ByOrderByCreatedAtDesc()
+                .stream()
+                .map(r -> ReviewResponseDto.builder()
+                        .gameType(r.getGameType())
+                        .nickname(r.getNickname())
+                        .grade(r.getGrade())
+                        .content(r.getContent())
+                        .build())
+                .toList();
+    }
+
+    public List<ReviewResponseDto> getRecentThreeReviews() {
+        return reviewRepository.findTop3ByOrderByCreatedAtDesc()
                 .stream()
                 .map(r -> ReviewResponseDto.builder()
                         .gameType(r.getGameType())
@@ -62,6 +75,19 @@ public class ReviewService {
                 .averageGrade(roundedAverage)
                 .monthlyReviewCount(reviewRepository.countReviewsByMonth(now.getYear(), now.getMonthValue()))
                 .build();
+    }
+
+    public List<ReviewResponseDto> getAllReviews() {
+        return reviewRepository.findAll().stream()
+                .map(r -> ReviewResponseDto.from(r))
+                .toList();
+    }
+
+    public void deleteReview(ReviewDeleteRequestDto request) {
+        if (!reviewRepository.existsById(request.getReviewId())) {
+            throw new IllegalArgumentException("해당 리뷰를 찾을 수 없습니다.");
+        }
+        reviewRepository.deleteById(request.getReviewId());
     }
 
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -13,3 +13,8 @@ springdoc:
   swagger-ui:
     tagsSorter: alpha
     operationsSorter: method
+
+server:
+  servlet:
+    session:
+      timeout: 1h  # 1시간 동안 활동 없으면 세션 만료


### PR DESCRIPTION
## 📋 Summary

> - closes #62 
**세션 시반 로그인 기능을 구현합니다.**

## ✅ Tasks

- 세션 기반 로그인 구현
- 세션 유지 구현
- 로그인 이후 관리자 페이지 접근 관리
- 세션 체크 이후 기능 이용 구현

## ✏️ To Reviewer

관리자 관련 페이지에 로그인과 접근 및 관리 권한에 관한 기능을 구현했습니다.
CRUD관련 기능 및 페이징 기능은 다음 작업에 추가합니다.

## 📷 Screenshot
<img width="1624" alt="스크린샷 2025-06-19 오후 5 24 03" src="https://github.com/user-attachments/assets/2dd54e8c-4620-41df-9fdc-19a2db9674a6" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 24 14" src="https://github.com/user-attachments/assets/7fa2205a-27b6-4f4d-8b8e-94786b0b0c89" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 24 37" src="https://github.com/user-attachments/assets/6fa01818-a230-4dc0-aaa6-c6e18509181a" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 25 08" src="https://github.com/user-attachments/assets/692c0466-5e32-4c20-94df-44c865e569f7" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 25 10" src="https://github.com/user-attachments/assets/8f01b815-95b0-4065-b869-bf7676ab7060" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 25 11" src="https://github.com/user-attachments/assets/9fb6e453-c8fb-4b7b-b9c4-c4ebcd108e45" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 25 16" src="https://github.com/user-attachments/assets/1651a76a-666d-4118-876f-08f5fb0314d0" />

<img width="1624" alt="스크린샷 2025-06-19 오후 5 25 40" src="https://github.com/user-attachments/assets/f16e727a-cb5d-4089-8bf4-766e1a88d833" />

